### PR TITLE
fix(release): install npm@latest so OIDC Trusted Publishers works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,12 @@ jobs:
       # ECMA-376 conformance tests shell out to xmllint (libxml2-utils).
       - run: sudo apt-get update && sudo apt-get install -y libxml2-utils
 
+      # `changeset publish` shells out to `npm publish`, and OIDC Trusted
+      # Publishers require npm CLI >= 11.5.1. Node 22 ships with npm 10.x,
+      # which only knows token auth and fails with ENEEDAUTH against the
+      # trusted-publisher flow.
+      - run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm typecheck


### PR DESCRIPTION
## Summary
- Install `npm@latest` ahead of `pnpm install` so `changeset publish` runs against an npm CLI that supports OIDC Trusted Publishers (>= 11.5.1)

## Why
After #15 wired the workflow to use OIDC instead of `NPM_TOKEN`, the 0.2.0 publish run still failed:

```
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
...
🦋 info Publishing "xlsx-kit" at "0.2.0"
🦋 error an error occurred while publishing xlsx-kit: ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org
🦋 error npm error code ENEEDAUTH
🦋 error npm error need auth This command requires you to be logged in to https://registry.npmjs.org
```

`changeset publish` shells out to `npm publish`, and the OIDC token-exchange endpoint that backs Trusted Publishers is only implemented in npm CLI **11.5.1+**. `actions/setup-node` with `node-version: 22` provisions npm 10.x, which has no idea what to do with an OIDC token and refuses the publish for lack of a static auth token.

Adding `npm install -g npm@latest` before the dependency install brings the publish command up to a CLI that completes the OIDC handshake. The 0.2.0 publish will retry on the next push to `main` after this lands.

## Test plan
- [ ] After merge, confirm the `Release` workflow run on `main` publishes `xlsx-kit@0.2.0` to npm with provenance and creates a `v0.2.0` GitHub Release
- [ ] `npm view xlsx-kit version` reports `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)