### PR TITLE
fix(release): bump publisher to Node 24 to get npm 11 for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,22 +47,24 @@ jobs:
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
+      # Use Node 24 here, not 22. `changeset publish` shells out to
+      # `npm publish`, and OIDC Trusted Publishers require npm CLI >= 11.5.1.
+      # Node 22 ships with npm 10.x, and `npm install -g npm@latest` on top
+      # of npm 10.x trips a self-upgrade bug (MODULE_NOT_FOUND: promise-retry).
+      # Node 24 ships with npm 11.x, so the OIDC publish path works out of
+      # the box without a separate npm install step. CI keeps testing the
+      # full Node 22/24/26 matrix; only the publish job needs a newer npm.
+      #
       # Note: do NOT set `registry-url` here — it would have setup-node write
       # `_authToken=${NODE_AUTH_TOKEN}` into .npmrc, which forces token auth
       # and blocks the OIDC code path used by Trusted Publishers.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       # ECMA-376 conformance tests shell out to xmllint (libxml2-utils).
       - run: sudo apt-get update && sudo apt-get install -y libxml2-utils
-
-      # `changeset publish` shells out to `npm publish`, and OIDC Trusted
-      # Publishers require npm CLI >= 11.5.1. Node 22 ships with npm 10.x,
-      # which only knows token auth and fails with ENEEDAUTH against the
-      # trusted-publisher flow.
-      - run: npm install -g npm@latest
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- Pin the `Release` job's `actions/setup-node` to `node-version: 24` so the bundled npm CLI is 11.x (>= 11.5.1) and OIDC Trusted Publishers works out of the box
- Drop the `npm install -g npm@latest` step added in #16 — it triggers an npm 10.x self-upgrade bug on the runner and never reaches the publish step

## Why
After #16 landed, the publish run still failed before reaching `changeset publish`:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
...
##[error]Process completed with exit code 1.
```

This is the well-known npm 10 → npm 11 self-upgrade corruption: while replacing its own `node_modules`, npm tries to require a file that's already been removed for the new install and crashes. The cleanest fix is to skip the in-place upgrade entirely.

Node 24 ships with npm 11.x by default, which already supports the OIDC token-exchange used by Trusted Publishers. Running the publish job on Node 24 gets us the right npm without an unstable upgrade dance. The full Node 22/24/26 test matrix in `ci.yml` is unaffected.

## Test plan
- [ ] After merge, confirm the `Release` workflow run on `main` publishes `xlsx-kit@0.2.0` to npm with provenance and creates a `v0.2.0` GitHub Release
- [ ] `npm view xlsx-kit version` reports `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)