### PR TITLE
chore(deps): update dependency typescript to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "size-limit": "^12.1.0",
     "tsdown": "^0.22.0",
     "typedoc": "^0.28.19",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   },
   "packageManager": "pnpm@10.33.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,13 +47,13 @@ importers:
         version: 12.1.0(jiti@2.7.0)
       tsdown:
         specifier: ^0.22.0
-        version: 0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)(unrun@0.2.37)
+        version: 0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(unrun@0.2.37)
       typedoc:
         specifier: ^0.28.19
-        version: 0.28.19(typescript@5.9.3)
+        version: 0.28.19(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.19.18)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.18)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.8.4))
@@ -2431,6 +2431,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -4435,7 +4440,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.25.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0)(typescript@5.9.3):
+  rolldown-plugin-dts@0.25.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.4
       '@babel/helper-validator-identifier': 8.0.0-rc.4
@@ -4447,7 +4452,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -4675,7 +4680,7 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  tsdown@0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)(unrun@0.2.37):
+  tsdown@0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(unrun@0.2.37):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -4686,14 +4691,14 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0
-      rolldown-plugin-dts: 0.25.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.25.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0)(typescript@6.0.3)
       semver: 7.7.4
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
       unrun: 0.2.37
     transitivePeerDependencies:
       - '@ts-macro/tsc'
@@ -4704,16 +4709,18 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  typedoc@0.28.19(typescript@5.9.3):
+  typedoc@0.28.19(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.1.1
       minimatch: 10.2.5
-      typescript: 5.9.3
+      typescript: 6.0.3
       yaml: 2.8.4
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,6 @@
     "noPropertyAccessFromIndexSignature": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": false,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true,


### PR DESCRIPTION
## Summary
- Bump TypeScript from `^5.9.3` to `^6.0.3`
- Drop `esModuleInterop: false` and `allowSyntheticDefaultImports: false` from `tsconfig.json` (both deprecated in TS 6, removed in TS 7)
- Supersedes #14 — please close that PR

## Why drop the two flags rather than `ignoreDeprecations: "6.0"`?
`verbatimModuleSyntax: true` is already set in `tsconfig.json`, which forbids the synthetic-default import patterns that `esModuleInterop=false` / `allowSyntheticDefaultImports=false` were defending against. Whether `esModuleInterop` resolves to `false` (TS 5 default) or `true` (TS 6 default), `verbatimModuleSyntax` enforces the same source-level import discipline, so the runtime/emit behavior of `xlsx-kit` is unchanged. Removing the explicit values means the project will keep tracking each TS major's defaults without another tsconfig nudge when TS 7 arrives.

## Verified locally on TS 6.0.3
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm test` — 2169/2169 passed
- [x] `pnpm build` — completes with no warnings beyond the existing tsdown `external` deprecation notice

## Test plan
- [ ] CI matrix (Node 22/24/26) passes
- [ ] After merge, `static` and `test (22|24|26)` jobs are green on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)