### PR TITLE
feat(node): add workbookToBuffer (#28)

### DIFF
--- a/.changeset/issue-28-workbook-to-buffer.md
+++ b/.changeset/issue-28-workbook-to-buffer.md
@@ -1,0 +1,7 @@
+---
+'xlsx-kit': minor
+---
+
+Add `workbookToBuffer` to `xlsx-kit/node`. One-shot Node-flavored helper
+that returns a `Buffer` directly, paralleling the existing `fromBuffer`
+source. Closes #28.

--- a/src/io/node-save.ts
+++ b/src/io/node-save.ts
@@ -1,0 +1,12 @@
+// Node-only counterpart to `workbookToBytes` in `./save`. Returns a Buffer
+// directly so Node consumers don't pay a `Buffer.from(uint8Array)` copy.
+
+import type { Workbook } from '../workbook/workbook';
+import { toBuffer } from './node';
+import { saveWorkbook, type SaveOptions } from './save';
+
+export async function workbookToBuffer(wb: Workbook, opts?: SaveOptions): Promise<Buffer> {
+  const sink = toBuffer();
+  await saveWorkbook(wb, sink, opts);
+  return sink.result();
+}

--- a/src/node.ts
+++ b/src/node.ts
@@ -3,3 +3,4 @@
 
 export { fromBuffer, toBuffer } from './io/node';
 export { fromFile, fromFileSync, fromReadable, toFile, toWritable } from './io/node-fs';
+export { workbookToBuffer } from './io/node-save';

--- a/tests/phase-1/io/issue-28-workbook-to-buffer.test.ts
+++ b/tests/phase-1/io/issue-28-workbook-to-buffer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { fromBuffer } from '../../../src/io/node';
+import { workbookToBuffer } from '../../../src/io/node-save';
+import { loadWorkbook } from '../../../src/io/load';
+import { workbookToBytes } from '../../../src/io/save';
+import { addWorksheet, createWorkbook } from '../../../src/workbook/workbook';
+import { getCell, setCell } from '../../../src/worksheet/worksheet';
+
+describe('workbookToBuffer (#28)', () => {
+  it('returns a Node Buffer', async () => {
+    const wb = createWorkbook();
+    addWorksheet(wb, 'Sheet1');
+    const buf = await workbookToBuffer(wb);
+    expect(Buffer.isBuffer(buf)).toBe(true);
+  });
+
+  it('produces the same bytes as workbookToBytes', async () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'Sheet1');
+    setCell(ws, 1, 1, 'a');
+    setCell(ws, 1, 2, 42);
+    setCell(ws, 2, 1, true);
+
+    const bufBytes = await workbookToBuffer(wb);
+    const u8Bytes = await workbookToBytes(wb);
+
+    expect(bufBytes.byteLength).toBe(u8Bytes.byteLength);
+    expect(Array.from(bufBytes)).toEqual(Array.from(u8Bytes));
+  });
+
+  it('round-trips through loadWorkbook(fromBuffer(...))', async () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'Roundtrip');
+    setCell(ws, 1, 1, 'hello');
+    setCell(ws, 2, 1, 7);
+
+    const buf = await workbookToBuffer(wb);
+    const wb2 = await loadWorkbook(fromBuffer(buf));
+    const ref = wb2.sheets[0];
+    if (ref === undefined || ref.kind !== 'worksheet') throw new Error('expected a worksheet');
+    const ws2 = ref.sheet;
+
+    expect(getCell(ws2, 1, 1)?.value).toBe('hello');
+    expect(getCell(ws2, 2, 1)?.value).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

- New `workbookToBuffer(wb, opts?)` in `xlsx-kit/node` — one-shot helper that returns a Node `Buffer` directly.
- Composes `saveWorkbook + toBuffer()` directly (rather than wrapping `workbookToBytes`), so the bytes the Node-only sink already builds are returned without an extra copy.
- `workbookToBytes` (Uint8Array) stays in `xlsx-kit/io` for browser / universal callers; this is the Node-flavored counterpart, mirroring the existing `fromBuffer` / universal-source split.

Closes #28. Spec: https://github.com/baseballyama/xlsx-kit/issues/28#issuecomment-4414469653

## Test plan

- [x] `pnpm vitest run tests/phase-1/io/issue-28-workbook-to-buffer.test.ts` — 3 passing (Buffer instance check, byte equivalence with `workbookToBytes`, round-trip via `loadWorkbook(fromBuffer(...))`).
- [x] `pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build && pnpm size` — all green; no bundle-size regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)