### PR TITLE
feat(cell): cellValueAsString opts + cellValueAsPrimitive (#25)

### DIFF
--- a/.changeset/issue-25-cell-value-helpers.md
+++ b/.changeset/issue-25-cell-value-helpers.md
@@ -1,0 +1,9 @@
+---
+'xlsx-kit': minor
+---
+
+Extend `cellValueAsString` (in `xlsx-kit/cell`) with optional
+`dateFormat` / `emptyText` overrides and add a sibling
+`cellValueAsPrimitive` that maps a `CellValue` to the most natural JS
+primitive (`string | number | boolean | Date | null`) without forcing a
+single target type. Closes #25.

--- a/src/cell/cell.ts
+++ b/src/cell/cell.ts
@@ -319,18 +319,30 @@ export function isDurationValue(v: CellValue): v is { kind: 'duration'; ms: numb
   return typeof v === 'object' && v !== null && (v as { kind?: string }).kind === 'duration';
 }
 
+export interface CellValueAsStringOptions {
+  /** Renderer for `Date` cells. Defaults to `d => d.toISOString()`. */
+  dateFormat?: (value: Date) => string;
+  /** Replacement for the `null` cell value. Defaults to `''`. */
+  emptyText?: string;
+}
+
 /**
  * Coerce a CellValue to its plain-string display form. Numbers / booleans
  * convert via `String`; rich text concatenates run text; formulas yield the
  * cached value (or empty string when uncached); errors yield their Excel token;
  * durations yield `"<ms> ms"` with no formatting; Dates yield
  * `Date.toISOString()`; `null` yields `""`.
+ *
+ * Pass `opts.dateFormat` to override the Date renderer (e.g. a locale-specific
+ * format) and `opts.emptyText` to substitute a different placeholder for
+ * `null` cells.
  */
-export function cellValueAsString(v: CellValue): string {
-  if (v === null) return '';
+export function cellValueAsString(v: CellValue, opts?: CellValueAsStringOptions): string {
+  const emptyText = opts?.emptyText ?? '';
+  if (v === null) return emptyText;
   if (typeof v === 'string') return v;
   if (typeof v === 'number' || typeof v === 'boolean') return String(v);
-  if (v instanceof Date) return v.toISOString();
+  if (v instanceof Date) return opts?.dateFormat ? opts.dateFormat(v) : v.toISOString();
   if (isRichTextValue(v)) return richTextToString(v.runs);
   if (isFormulaValue(v)) {
     if (v.cachedValue === undefined) return '';
@@ -403,4 +415,30 @@ export function cellValueAsNumber(v: CellValue): number | undefined {
   }
   if (isFormulaValue(v) && typeof v.cachedValue === 'number') return v.cachedValue;
   return undefined;
+}
+
+/**
+ * Map a CellValue to the most natural JS primitive for display / export.
+ * Unlike `cellValueAsString`/`cellValueAsNumber`/etc., which each force a
+ * single target type and return `undefined` when the value can't be coerced,
+ * this returns whatever primitive best represents the union variant:
+ *
+ * - `null` → `null`
+ * - `string` / `number` / `boolean` / `Date` → passthrough
+ * - rich text → joined run text (`string`)
+ * - formula → recursive on `cachedValue` (`null` when uncached)
+ * - error → error code (`string`)
+ * - duration → `ms` (`number`)
+ */
+export function cellValueAsPrimitive(v: CellValue): string | number | boolean | Date | null {
+  if (v === null) return null;
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return v;
+  if (v instanceof Date) return v;
+  if (isRichTextValue(v)) return richTextToString(v.runs);
+  if (isFormulaValue(v)) {
+    return v.cachedValue === undefined ? null : v.cachedValue;
+  }
+  if (isErrorValue(v)) return v.code;
+  if (isDurationValue(v)) return v.ms;
+  return null;
 }

--- a/src/cell/index.ts
+++ b/src/cell/index.ts
@@ -4,6 +4,7 @@
 export type {
   Cell,
   CellValue,
+  CellValueAsStringOptions,
   DataTableFormulaOpts,
   ExcelErrorCode,
   FormulaKind,
@@ -15,6 +16,7 @@ export {
   cellValueAsBoolean,
   cellValueAsDate,
   cellValueAsNumber,
+  cellValueAsPrimitive,
   cellValueAsString,
   getCachedFormulaValue,
   getCoordinate,

--- a/tests/phase-2/issue-25-cell-value-helpers.test.ts
+++ b/tests/phase-2/issue-25-cell-value-helpers.test.ts
@@ -1,0 +1,72 @@
+// Tests for the #25 additions: cellValueAsString opts (dateFormat / emptyText)
+// + the new cellValueAsPrimitive helper.
+
+import { describe, expect, it } from 'vitest';
+import {
+  cellValueAsPrimitive,
+  cellValueAsString,
+  makeDurationValue,
+  makeErrorValue,
+} from '../../src/cell/cell';
+import { makeRichText } from '../../src/cell/rich-text';
+
+describe('cellValueAsString — options (#25)', () => {
+  it('emptyText overrides the null placeholder', () => {
+    expect(cellValueAsString(null, { emptyText: '—' })).toBe('—');
+  });
+
+  it('emptyText only applies to null, not to formula-with-no-cached-value', () => {
+    const f = { kind: 'formula' as const, t: 'normal' as const, formula: 'A1+1' };
+    // Uncached formula still returns '' regardless of emptyText.
+    expect(cellValueAsString(f, { emptyText: '—' })).toBe('');
+  });
+
+  it('dateFormat overrides the Date renderer', () => {
+    const d = new Date('2024-01-02T03:04:05Z');
+    expect(cellValueAsString(d, { dateFormat: (v) => v.getUTCFullYear().toString() })).toBe('2024');
+  });
+
+  it('default behavior is byte-for-byte unchanged when opts is undefined', () => {
+    expect(cellValueAsString(null)).toBe('');
+    expect(cellValueAsString(42)).toBe('42');
+    expect(cellValueAsString(new Date('2024-01-02T03:04:05Z'))).toBe('2024-01-02T03:04:05.000Z');
+    expect(cellValueAsString(makeDurationValue(1500))).toBe('1500 ms');
+  });
+});
+
+describe('cellValueAsPrimitive (#25)', () => {
+  it('null → null', () => {
+    expect(cellValueAsPrimitive(null)).toBe(null);
+  });
+
+  it('passes through string / number / boolean / Date', () => {
+    expect(cellValueAsPrimitive('hi')).toBe('hi');
+    expect(cellValueAsPrimitive(42)).toBe(42);
+    expect(cellValueAsPrimitive(true)).toBe(true);
+    const d = new Date('2024-01-02T03:04:05Z');
+    expect(cellValueAsPrimitive(d)).toBe(d);
+  });
+
+  it('rich-text → joined run text (string)', () => {
+    const rt = makeRichText([{ text: 'Hello ' }, { text: 'world', font: { b: true } }]);
+    expect(cellValueAsPrimitive({ kind: 'rich-text', runs: rt })).toBe('Hello world');
+  });
+
+  it('formula with cachedValue → cachedValue', () => {
+    const f = { kind: 'formula' as const, t: 'normal' as const, formula: 'A1+1', cachedValue: 7 };
+    expect(cellValueAsPrimitive(f)).toBe(7);
+  });
+
+  it('formula without cachedValue → null', () => {
+    const f = { kind: 'formula' as const, t: 'normal' as const, formula: 'A1+1' };
+    expect(cellValueAsPrimitive(f)).toBe(null);
+  });
+
+  it('error → error code (string)', () => {
+    expect(cellValueAsPrimitive(makeErrorValue('#NAME?'))).toBe('#NAME?');
+  });
+
+  it('duration → ms (number)', () => {
+    expect(cellValueAsPrimitive(makeDurationValue(1500))).toBe(1500);
+  });
+});


### PR DESCRIPTION
## Summary

- Extend `cellValueAsString` with optional `dateFormat` / `emptyText` overrides (defaults byte-for-byte unchanged when `opts` is undefined).
- Add `cellValueAsPrimitive`: maps a `CellValue` to the most natural JS primitive (`string | number | boolean | Date | null`) — fills the gap left by the type-targeted `cellValueAsBoolean` / `cellValueAsDate` / `cellValueAsNumber` family.

Closes #25. Spec: https://github.com/baseballyama/xlsx-kit/issues/25#issuecomment-4414803617 (revised after discovering the existing `cellValueAs*` family).

## Notes

- The original issue proposed `cellValueToString` / `cellValueToPrimitive`. The first overlapped with the existing `cellValueAsString`, so it became an opts extension rather than a parallel helper. The second was renamed to `cellValueAsPrimitive` to match the existing family.
- `emptyText` only applies to `null` cells; formula values with no `cachedValue` keep returning `''` (semantically "no cached value", not "empty").

## Test plan

- [x] `pnpm vitest run tests/phase-2/issue-25-cell-value-helpers.test.ts` — 11 passing.
- [x] `pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build && pnpm size` — all green; no bundle-size regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)