### PR TITLE
feat(worksheet)!: rectangular iterRows / iterValues (#24)

### DIFF
--- a/.changeset/issue-24-rectangular-iter-rows.md
+++ b/.changeset/issue-24-rectangular-iter-rows.md
@@ -1,0 +1,23 @@
+---
+'xlsx-kit': major
+---
+
+**Breaking**: `iterRows` / `iterValues` (in `xlsx-kit/worksheet`) now
+iterate **rectangularly** over the populated bounding box rather than
+skipping empty rows and gaps. `iterRows` yields
+`(Cell | undefined)[]` (one entry per `[minCol, maxCol]` position);
+`iterValues` yields `CellValue[]` with `null` filling the gaps.
+
+Default extent switches from `MAX_ROW`/`MAX_COL` (the 1M × 16K sheet
+limit) to `getMaxRow(ws)` / `getMaxCol(ws)` (the populated bounding
+box). The `IterRowsOptions.valuesOnly` flag is removed — it was already
+unread.
+
+Migration:
+
+- Aggregation callers that want populated rows only:
+  `[...iterRows(ws)].filter((row) => row.some((c) => c !== undefined))`.
+- Cell-by-cell streaming over populated cells only: keep using `iterCells`
+  (unchanged).
+
+Closes #24.

--- a/src/worksheet/worksheet.ts
+++ b/src/worksheet/worksheet.ts
@@ -430,46 +430,64 @@ export interface IterRowsOptions {
   maxRow?: number;
   minCol?: number;
   maxCol?: number;
-  /** Yield cell values instead of Cell objects. */
-  valuesOnly?: boolean;
 }
 
 /**
- * Iterate the populated cells row-by-row in ascending order. Empty rows are
- * skipped (no `[]` yielded). Within a row, cells are sorted by column index
- * ascending.
+ * Iterate the worksheet rows rectangularly. Yields one row per row in
+ * `[minRow, maxRow]` — including entirely empty rows — and each yielded row
+ * has length `maxCol - minCol + 1`. Missing cell positions are `undefined`
+ * (no placeholder Cell allocations).
+ *
+ * Defaults: `minRow=1`, `maxRow=getMaxRow(ws)`, `minCol=1`,
+ * `maxCol=getMaxCol(ws)`. The default extent is the populated bounding box,
+ * not the 1M × 16K sheet limit, so the rectangular default doesn't iterate
+ * the whole grid for a small sheet.
+ *
+ * To iterate populated rows only, filter:
+ * `[...iterRows(ws)].filter(row => row.some((c) => c !== undefined))`. To
+ * iterate populated cells without row boundaries, use {@link iterCells}.
  */
-export function* iterRows(ws: Worksheet, opts: IterRowsOptions = {}): IterableIterator<Cell[]> {
-  const { minRow = 1, maxRow = MAX_ROW, minCol = 1, maxCol = MAX_COL } = opts;
-  const rowKeys = [...ws.rows.keys()].filter((r) => r >= minRow && r <= maxRow).sort((a, b) => a - b);
-  for (const r of rowKeys) {
+export function* iterRows(ws: Worksheet, opts: IterRowsOptions = {}): IterableIterator<(Cell | undefined)[]> {
+  const { minRow = 1, maxRow = getMaxRow(ws), minCol = 1, maxCol = getMaxCol(ws) } = opts;
+  if (maxRow < minRow || maxCol < minCol) return;
+  const width = maxCol - minCol + 1;
+  for (let r = minRow; r <= maxRow; r++) {
     const rowMap = ws.rows.get(r);
-    if (rowMap === undefined) continue;
-    const cols = [...rowMap.keys()].filter((c) => c >= minCol && c <= maxCol).sort((a, b) => a - b);
-    if (cols.length === 0) continue;
-    const out: Cell[] = [];
-    for (const c of cols) {
-      const cell = rowMap.get(c);
-      if (cell !== undefined) out.push(cell);
+    // Fill explicitly so the array isn't sparse — `.map` callbacks would skip
+    // empty slots and surprise the caller.
+    const out: (Cell | undefined)[] = new Array(width).fill(undefined);
+    if (rowMap !== undefined) {
+      for (let c = minCol; c <= maxCol; c++) {
+        const cell = rowMap.get(c);
+        if (cell !== undefined) out[c - minCol] = cell;
+      }
     }
     yield out;
   }
 }
 
-/** Same as `iterRows` but yields each cell's `.value`. */
+/**
+ * Same rectangular iteration as {@link iterRows}, but yields each cell's
+ * `.value`. Missing cell positions become `null` — already the canonical empty
+ * marker in `CellValue`.
+ */
 export function* iterValues(ws: Worksheet, opts: IterRowsOptions = {}): IterableIterator<CellValue[]> {
-  for (const row of iterRows(ws, opts)) yield row.map((c) => c.value);
+  for (const row of iterRows(ws, opts)) {
+    yield row.map((c) => (c === undefined ? null : c.value));
+  }
 }
 
 /**
  * Yield every populated cell in the worksheet as a flat stream (row-major,
- * columns ascending). Distinct from {@link iterRows} which yields one Cell[]
- * per populated row — use this when the caller doesn't care about row
- * boundaries.
+ * columns ascending). Distinct from {@link iterRows} which yields one row
+ * per row in the bounding box — use this when the caller wants only the
+ * populated cells without row boundaries or rectangular padding.
  */
 export function* iterCells(ws: Worksheet, opts: IterRowsOptions = {}): IterableIterator<Cell> {
   for (const row of iterRows(ws, opts)) {
-    for (const cell of row) yield cell;
+    for (const cell of row) {
+      if (cell !== undefined) yield cell;
+    }
   }
 }
 

--- a/tests/phase-2/issue-24-rectangular-iter-rows.test.ts
+++ b/tests/phase-2/issue-24-rectangular-iter-rows.test.ts
@@ -1,0 +1,124 @@
+// Coverage for the #24 redesign: iterRows / iterValues yield rectangular
+// rows over the populated bounding box, not just the populated cells.
+
+import { describe, expect, it } from 'vitest';
+import { addWorksheet, createWorkbook } from '../../src/workbook/workbook';
+import { iterCells, iterRows, iterValues, setCell } from '../../src/worksheet/worksheet';
+
+describe('iterRows — rectangular default (#24)', () => {
+  it('default extent is the populated bounding box', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    setCell(ws, 1, 1, 'a');
+    setCell(ws, 3, 3, 'c');
+    // Populated extent: rows 1..3, cols 1..3 → 3x3 rectangle.
+    const rows = [...iterRows(ws)].map((row) => row.map((c) => c?.value ?? null));
+    expect(rows).toEqual([
+      ['a', null, null],
+      [null, null, null],
+      [null, null, 'c'],
+    ]);
+  });
+
+  it('yields one row per row in [minRow, maxRow] including entirely empty rows', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    setCell(ws, 1, 1, 'a');
+    setCell(ws, 4, 1, 'd');
+    const rows = [...iterRows(ws, { minRow: 1, maxRow: 4, minCol: 1, maxCol: 1 })].map((row) =>
+      row.map((c) => c?.value ?? null),
+    );
+    expect(rows.length).toBe(4);
+    expect(rows).toEqual([['a'], [null], [null], ['d']]);
+  });
+
+  it('rectangular rows match maxCol - minCol + 1 in width', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    setCell(ws, 1, 1, 'a');
+    setCell(ws, 1, 3, 'c');
+    const rows = [...iterRows(ws, { minRow: 1, maxRow: 1, minCol: 1, maxCol: 5 })];
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.length).toBe(5);
+  });
+
+  it('explicit maxRow past populated extent emits trailing empty rows', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    setCell(ws, 1, 1, 'a');
+    const rows = [...iterRows(ws, { minRow: 1, maxRow: 4, minCol: 1, maxCol: 1 })].map((row) =>
+      row.map((c) => c?.value ?? null),
+    );
+    expect(rows).toEqual([['a'], [null], [null], [null]]);
+  });
+
+  it('inverted ranges yield nothing without throwing', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    setCell(ws, 1, 1, 'a');
+    expect([...iterRows(ws, { minRow: 5, maxRow: 2 })]).toEqual([]);
+    expect([...iterRows(ws, { minCol: 5, maxCol: 2 })]).toEqual([]);
+  });
+
+  it('empty worksheet yields no rows under default extent', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    expect([...iterRows(ws)]).toEqual([]);
+  });
+});
+
+describe('iterValues — rectangular (#24)', () => {
+  it('fills missing cells with null, not undefined', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    setCell(ws, 1, 1, 'a');
+    setCell(ws, 1, 3, 'c');
+    setCell(ws, 3, 2, 'b');
+    const values = [...iterValues(ws)];
+    expect(values).toEqual([
+      ['a', null, 'c'],
+      [null, null, null],
+      [null, 'b', null],
+    ]);
+    // null is a valid CellValue; undefined is not.
+    for (const row of values) {
+      for (const v of row) expect(v === undefined).toBe(false);
+    }
+  });
+
+  it('round-trips: re-applying via setCell reproduces the same iterValues output', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    setCell(ws, 1, 1, 'a');
+    setCell(ws, 1, 3, 'c');
+    setCell(ws, 3, 2, 'b');
+    const before = [...iterValues(ws)];
+
+    const wb2 = createWorkbook();
+    const ws2 = addWorksheet(wb2, 'S2');
+    for (let r = 0; r < before.length; r++) {
+      const row = before[r];
+      if (!row) continue;
+      for (let c = 0; c < row.length; c++) {
+        const v = row[c];
+        if (v !== null) setCell(ws2, r + 1, c + 1, v);
+      }
+    }
+    const after = [...iterValues(ws2)];
+    expect(after).toEqual(before);
+  });
+});
+
+describe('iterCells — populated only, unchanged behavior (#24)', () => {
+  it('still skips undefined positions; yields only populated cells', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    setCell(ws, 1, 1, 'a');
+    setCell(ws, 3, 3, 'c');
+    const cells = [...iterCells(ws)];
+    expect(cells.map((c) => [c.row, c.col, c.value])).toEqual([
+      [1, 1, 'a'],
+      [3, 3, 'c'],
+    ]);
+  });
+});

--- a/tests/phase-2/workbook.test.ts
+++ b/tests/phase-2/workbook.test.ts
@@ -193,17 +193,22 @@ describe('appendRow', () => {
 });
 
 describe('iterRows / iterValues', () => {
-  it('iterates rows in ascending order, skipping empty rows', () => {
+  it('iterates rows rectangularly, including empty rows', () => {
     const wb = createWorkbook();
     const ws = addWorksheet(wb, 'S');
     setCell(ws, 1, 1, 'a');
     setCell(ws, 3, 1, 'b'); // gap on row 2
     setCell(ws, 3, 2, 'c');
-    const rows = [...iterRows(ws)].map((row) => row.map((c) => c.value));
-    expect(rows).toEqual([['a'], ['b', 'c']]);
+    // Default extent = rows 1..3, cols 1..2 (populated bounding box).
+    const rows = [...iterRows(ws)].map((row) => row.map((c) => c?.value ?? null));
+    expect(rows).toEqual([
+      ['a', null], // row 1: only col 1 populated
+      [null, null], // row 2: empty
+      ['b', 'c'], // row 3: both populated
+    ]);
   });
 
-  it('honours minRow / maxRow / minCol / maxCol filters', () => {
+  it('honours minRow / maxRow / minCol / maxCol filters and pads rectangularly', () => {
     const wb = createWorkbook();
     const ws = addWorksheet(wb, 'S');
     setCell(ws, 1, 1, 'a');
@@ -211,13 +216,16 @@ describe('iterRows / iterValues', () => {
     setCell(ws, 2, 3, 'c');
     setCell(ws, 5, 5, 'd');
     const rows = [...iterRows(ws, { minRow: 1, maxRow: 2, minCol: 1, maxCol: 4 })].map((row) =>
-      row.map((c) => c.value),
+      row.map((c) => c?.value ?? null),
     );
-    // row1 col1 only; row2 col3 only; row5 filtered out.
-    expect(rows).toEqual([['a'], ['c']]);
+    // 4-wide rectangle, rows 1 and 2.
+    expect(rows).toEqual([
+      ['a', null, null, null],
+      [null, null, 'c', null],
+    ]);
   });
 
-  it('iterValues yields the cell values directly', () => {
+  it('iterValues fills gaps with null', () => {
     const wb = createWorkbook();
     const ws = addWorksheet(wb, 'S');
     appendRow(ws, [1, 2, 3]);
@@ -226,6 +234,14 @@ describe('iterRows / iterValues', () => {
       [1, 2, 3],
       [4, 5, 6],
     ]);
+  });
+
+  it('iterValues yields null for missing cells in a sparse row', () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'S');
+    setCell(ws, 1, 1, 'a');
+    setCell(ws, 1, 3, 'c');
+    expect([...iterValues(ws)]).toEqual([['a', null, 'c']]);
   });
 });
 

--- a/tests/phase-3/genuine-roundtrip.test.ts
+++ b/tests/phase-3/genuine-roundtrip.test.ts
@@ -98,6 +98,7 @@ const collectCells = (ws: Worksheet): Array<{ row: number; col: number; value: u
   const out: Array<{ row: number; col: number; value: unknown; styleId: number }> = [];
   for (const cells of iterRows(ws)) {
     for (const c of cells) {
+      if (c === undefined) continue;
       out.push({ row: c.row, col: c.col, value: c.value, styleId: c.styleId });
     }
   }

--- a/tests/phase-4/write-only.test.ts
+++ b/tests/phase-4/write-only.test.ts
@@ -40,11 +40,13 @@ describe('createWriteOnlyWorkbook — basic round-trip', () => {
     const ws2 = wb2.sheets[0];
     if (!ws2 || ws2.kind !== 'worksheet') throw new Error('expected worksheet');
     const rows: unknown[][] = [];
-    for (const cells of iterRows(ws2.sheet)) rows.push(cells.map((c) => c.value));
+    for (const cells of iterRows(ws2.sheet)) rows.push(cells.map((c) => c?.value ?? null));
     expect(rows).toEqual([
       [1, 2, 3],
       ['a', 'b', 'c'],
-      [true, false],
+      // Row 3 col 3 is null and write-only skips emitting null cells, so the
+      // rectangular iter pads it with null to match the bounding-box width.
+      [true, false, null],
     ]);
   });
 
@@ -125,7 +127,7 @@ describe('createWriteOnlyWorkbook — styles + sharedStrings', () => {
     if (!ws || ws.kind !== 'worksheet') throw new Error('expected worksheet');
     const rows: { value: unknown; styleId: number }[][] = [];
     for (const cells of iterRows(ws.sheet)) {
-      rows.push(cells.map((c) => ({ value: c.value, styleId: c.styleId })));
+      rows.push(cells.map((c) => (c === undefined ? { value: null, styleId: 0 } : { value: c.value, styleId: c.styleId })));
     }
     // Two cells share the same styleId; the unstyled cell uses 0.
     const styled1 = rows[0]?.[0];


### PR DESCRIPTION
## Summary

Breaking redesign of `iterRows` / `iterValues` (in `xlsx-kit/worksheet`) so rectangular iteration over the populated bounding box is the only mode — replacing the previous "skip empty rows + skip empty cells within a row" behavior.

- `iterRows` yields `(Cell | undefined)[]`, one entry per position in `[minCol, maxCol]`. Missing cells are `undefined` (no placeholder Cell allocations).
- `iterValues` yields `CellValue[]` with `null` filling the gaps — `null` is already the canonical empty marker in the union.
- Default `maxRow` / `maxCol` switch from `MAX_ROW` / `MAX_COL` (the full 1M × 16K sheet limit) to `getMaxRow(ws)` / `getMaxCol(ws)` so the rectangular default doesn't iterate the whole grid for a small sheet.
- `IterRowsOptions.valuesOnly` removed — declared but never read (the worksheet API has the dedicated `iterValues` function instead).
- `iterCells` is unchanged (still "populated cells only").

Closes #24. Spec: https://github.com/baseballyama/xlsx-kit/issues/24#issuecomment-4414469082

## Migration

| Want | Before | After |
|---|---|---|
| Iterate rectangular rows | `getCell` double-loop with `getMaxRow` / `getMaxCol` | just `iterRows(ws)` |
| Iterate populated rows only | `iterRows(ws)` | `[...iterRows(ws)].filter((row) => row.some((c) => c !== undefined))` |
| Iterate populated cells flat | `iterCells(ws)` | `iterCells(ws)` (unchanged) |
| Get cell values with `null` for gaps | reconstruct manually | `iterValues(ws)` |

## Notes

- This is a breaking change tagged as `major` in the changeset, since the public API contract changes (`iterRows` return type went from `Cell[]` to `(Cell | undefined)[]`; rectangular semantics replace skip-empty semantics).
- Streaming `iterRows` (in `xlsx-kit/streaming`) is **unchanged** — it's a separate function with its own implementation. Whether to align it with the new rectangular semantics is a follow-up question.
- Existing test-suite callers are updated to the new shape.

## Test plan

- [x] `pnpm vitest run tests/phase-2/issue-24-rectangular-iter-rows.test.ts` — 9 new cases (default extent = bounding box; rectangular padding for sparse rows; explicit maxRow past extent; inverted ranges; `iterValues` round-trip; `iterCells` unchanged).
- [x] `pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build && pnpm size` — all green; no bundle-size regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)