### PR TITLE
chore(changeset): keep 0.x for iterRows breaking change

### DIFF
--- a/.changeset/issue-24-rectangular-iter-rows.md
+++ b/.changeset/issue-24-rectangular-iter-rows.md
@@ -1,5 +1,5 @@
 ---
-'xlsx-kit': major
+'xlsx-kit': minor
 ---
 
 **Breaking**: `iterRows` / `iterValues` (in `xlsx-kit/worksheet`) now


### PR DESCRIPTION
## Summary
- Switch the `iterRows` / `iterValues` changeset bump level from `major` to `minor` so the next release stays within 0.x.
- Pre-1.0, breaking changes are signalled via a minor bump; otherwise the rectangular-iter change would have pushed `xlsx-kit` to 1.0.0.

## Test plan
- [ ] Confirm `pnpm changeset version` (or the release workflow dry-run) bumps `xlsx-kit` to `0.3.0`, not `1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)