### PR TITLE
feat(site): client-side search via Pagefind (#34)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       mdsvex:
         specifier: ^0.12.7
         version: 0.12.7(svelte@5.55.5)
+      pagefind:
+        specifier: ^1.4.0
+        version: 1.5.2
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
@@ -547,9 +550,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-project/types@0.127.0':
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
-
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
 
@@ -786,6 +786,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pagefind/darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pagefind/darwin-x64@1.5.2':
+    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@pagefind/linux-arm64@1.5.2':
+    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pagefind/linux-x64@1.5.2':
+    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pagefind/windows-arm64@1.5.2':
+    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pagefind/windows-x64@1.5.2':
+    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
+    cpu: [x64]
+    os: [win32]
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -794,12 +829,6 @@ packages:
 
   '@rolldown/binding-android-arm64@1.0.0':
     resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -816,12 +845,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -830,12 +853,6 @@ packages:
 
   '@rolldown/binding-darwin-x64@1.0.0':
     resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -852,12 +869,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
     resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -870,12 +881,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
     resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -884,13 +889,6 @@ packages:
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0':
     resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -910,13 +908,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -926,13 +917,6 @@ packages:
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -952,13 +936,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -968,13 +945,6 @@ packages:
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -994,13 +964,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1010,12 +973,6 @@ packages:
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1031,11 +988,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
     resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1043,12 +995,6 @@ packages:
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0':
     resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -1065,12 +1011,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1079,9 +1019,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.0':
     resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
-
-  '@rolldown/pluginutils@1.0.0-rc.17':
-    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rolldown/pluginutils@1.0.0-rc.18':
     resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
@@ -1877,6 +1814,10 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  pagefind@1.5.2:
+    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
+    hasBin: true
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1995,11 +1936,6 @@ packages:
 
   rolldown@1.0.0:
     resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rolldown@1.0.0-rc.17:
-    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2829,9 +2765,6 @@ snapshots:
   '@oxc-parser/binding-win32-x64-msvc@0.128.0':
     optional: true
 
-  '@oxc-project/types@0.127.0':
-    optional: true
-
   '@oxc-project/types@0.128.0': {}
 
   '@oxc-project/types@0.129.0': {}
@@ -2958,6 +2891,27 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.63.0':
     optional: true
 
+  '@pagefind/darwin-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/darwin-x64@1.5.2':
+    optional: true
+
+  '@pagefind/freebsd-x64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-x64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-x64@1.5.2':
+    optional: true
+
   '@polka/url@1.0.0-next.29': {}
 
   '@quansync/fs@1.0.0':
@@ -2967,16 +2921,10 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
@@ -2985,16 +2933,10 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
@@ -3003,16 +2945,10 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
@@ -3021,16 +2957,10 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
@@ -3039,16 +2969,10 @@ snapshots:
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
@@ -3057,29 +2981,16 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
@@ -3096,25 +3007,16 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     optional: true
 
   '@rolldown/pluginutils@1.0.0': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.17':
-    optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.18': {}
 
@@ -3954,6 +3856,16 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  pagefind@1.5.2:
+    optionalDependencies:
+      '@pagefind/darwin-arm64': 1.5.2
+      '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
+      '@pagefind/linux-arm64': 1.5.2
+      '@pagefind/linux-x64': 1.5.2
+      '@pagefind/windows-arm64': 1.5.2
+      '@pagefind/windows-x64': 1.5.2
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.5.0: {}
@@ -4057,28 +3969,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0
       '@rolldown/binding-win32-arm64-msvc': 1.0.0
       '@rolldown/binding-win32-x64-msvc': 1.0.0
-
-  rolldown@1.0.0-rc.17:
-    dependencies:
-      '@oxc-project/types': 0.127.0
-      '@rolldown/pluginutils': 1.0.0-rc.17
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
-    optional: true
 
   rolldown@1.0.0-rc.18:
     dependencies:

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "vite build && pagefind --site build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
@@ -16,6 +16,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/node": "^22.19.18",
     "mdsvex": "^0.12.7",
+    "pagefind": "^1.4.0",
     "shiki": "^4.0.2",
     "svelte": "^5.55.5",
     "svelte-check": "^4.4.8",

--- a/site/src/lib/components/Search.svelte
+++ b/site/src/lib/components/Search.svelte
@@ -24,10 +24,12 @@
   };
 
   let open = $state(false);
+  // eslint-disable-next-line prefer-const -- reassigned by `bind:value` in template
   let query = $state('');
   let hits = $state<Hit[]>([]);
   let pagefind = $state<PagefindModule | null>(null);
   let status = $state<'idle' | 'loading' | 'ready' | 'unavailable'>('idle');
+  // eslint-disable-next-line prefer-const -- reassigned by `bind:this` in template
   let inputEl = $state<HTMLInputElement | null>(null);
 
   async function loadPagefind(): Promise<PagefindModule | null> {
@@ -99,7 +101,8 @@
   function onKeyDown(e: KeyboardEvent): void {
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
-      open ? closeModal() : openModal();
+      if (open) closeModal();
+      else openModal();
     } else if (e.key === 'Escape' && open) {
       closeModal();
     } else if (e.key === '/' && !open && !isTypingTarget(e.target)) {

--- a/site/src/lib/components/Search.svelte
+++ b/site/src/lib/components/Search.svelte
@@ -35,15 +35,21 @@
     if (status === 'unavailable') return null;
     status = 'loading';
     try {
-      // Pagefind generates this file at build time; in `vite dev` it doesn't
-      // exist, so the dynamic import fails and we surface "unavailable".
-      const url = `${base}/pagefind/pagefind.js`;
-      const mod = (await import(/* @vite-ignore */ url)) as PagefindModule;
-      await mod.options?.({ baseUrl: `${base}/` });
+      // SvelteKit's `paths.relative: true` means `base` is relative to the
+      // current page (e.g. `..`/`../..`). A bare dynamic import would resolve
+      // that against the JS chunk's URL, not the page's — so we anchor to
+      // `document.baseURI` to land at the site-root pagefind directory.
+      // Pagefind generates these files at build time; in `vite dev` they
+      // don't exist, so the import fails and we surface "unavailable".
+      const pagefindUrl = new URL(`${base}/pagefind/pagefind.js`, document.baseURI);
+      const siteRoot = new URL(`${base}/`, document.baseURI);
+      const mod = (await import(/* @vite-ignore */ pagefindUrl.href)) as PagefindModule;
+      await mod.options?.({ baseUrl: siteRoot.pathname });
       pagefind = mod;
       status = 'ready';
       return mod;
-    } catch {
+    } catch (err) {
+      console.error('[xlsx-kit search] failed to load pagefind index', err);
       status = 'unavailable';
       return null;
     }

--- a/site/src/lib/components/Search.svelte
+++ b/site/src/lib/components/Search.svelte
@@ -1,0 +1,348 @@
+<script lang="ts">
+  import { base } from '$app/paths';
+  import { onMount } from 'svelte';
+
+  type PagefindResult = {
+    id: string;
+    data: () => Promise<{
+      url: string;
+      excerpt: string;
+      meta: { title?: string };
+      sub_results?: Array<{ title: string; url: string; excerpt: string }>;
+    }>;
+  };
+
+  type PagefindModule = {
+    search(query: string): Promise<{ results: PagefindResult[] }>;
+    options?(opts: { baseUrl?: string }): Promise<void>;
+  };
+
+  type Hit = {
+    url: string;
+    title: string;
+    excerpt: string;
+  };
+
+  let open = $state(false);
+  let query = $state('');
+  let hits = $state<Hit[]>([]);
+  let pagefind = $state<PagefindModule | null>(null);
+  let status = $state<'idle' | 'loading' | 'ready' | 'unavailable'>('idle');
+  let inputEl = $state<HTMLInputElement | null>(null);
+
+  async function loadPagefind(): Promise<PagefindModule | null> {
+    if (pagefind) return pagefind;
+    if (status === 'unavailable') return null;
+    status = 'loading';
+    try {
+      // Pagefind generates this file at build time; in `vite dev` it doesn't
+      // exist, so the dynamic import fails and we surface "unavailable".
+      const url = `${base}/pagefind/pagefind.js`;
+      const mod = (await import(/* @vite-ignore */ url)) as PagefindModule;
+      await mod.options?.({ baseUrl: `${base}/` });
+      pagefind = mod;
+      status = 'ready';
+      return mod;
+    } catch {
+      status = 'unavailable';
+      return null;
+    }
+  }
+
+  async function runSearch(q: string): Promise<void> {
+    const trimmed = q.trim();
+    if (!trimmed) {
+      hits = [];
+      return;
+    }
+    const pf = await loadPagefind();
+    if (!pf) return;
+    const search = await pf.search(trimmed);
+    if (q !== query) return; // a newer keystroke landed; drop stale results
+    const top = await Promise.all(search.results.slice(0, 10).map((r) => r.data()));
+    hits = top.map((d) => ({
+      url: d.url,
+      title: d.meta.title ?? d.url,
+      excerpt: d.excerpt,
+    }));
+  }
+
+  $effect(() => {
+    void runSearch(query);
+  });
+
+  function openModal(): void {
+    open = true;
+    void loadPagefind();
+    queueMicrotask(() => inputEl?.focus());
+  }
+
+  function closeModal(): void {
+    open = false;
+  }
+
+  function onKeyDown(e: KeyboardEvent): void {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      open ? closeModal() : openModal();
+    } else if (e.key === 'Escape' && open) {
+      closeModal();
+    } else if (e.key === '/' && !open && !isTypingTarget(e.target)) {
+      e.preventDefault();
+      openModal();
+    }
+  }
+
+  function isTypingTarget(t: EventTarget | null): boolean {
+    if (!(t instanceof HTMLElement)) return false;
+    const tag = t.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || t.isContentEditable;
+  }
+
+  onMount(() => {
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  });
+</script>
+
+<button
+  type="button"
+  class="trigger"
+  onclick={openModal}
+  aria-label="Search docs (press / or Cmd-K)"
+  data-pagefind-ignore
+>
+  <span class="trigger-label">Search</span>
+  <kbd class="trigger-kbd">⌘K</kbd>
+</button>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="overlay" role="presentation" onclick={closeModal} data-pagefind-ignore>
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search"
+      tabindex="-1"
+      onclick={(e) => e.stopPropagation()}
+    >
+      <div class="input-row">
+        <input
+          bind:this={inputEl}
+          bind:value={query}
+          type="search"
+          placeholder="Search docs and API…"
+          autocomplete="off"
+          spellcheck="false"
+          class="input"
+        />
+        <kbd class="esc">Esc</kbd>
+      </div>
+
+      <div class="results" aria-live="polite">
+        {#if status === 'unavailable'}
+          <p class="status">
+            Search index not available. Run <code>pnpm --filter xlsx-kit-site build</code>
+            to generate it (the dev server skips indexing).
+          </p>
+        {:else if status === 'loading' && hits.length === 0}
+          <p class="status">Loading search index…</p>
+        {:else if query.trim() && hits.length === 0 && status === 'ready'}
+          <p class="status">No results for "{query}".</p>
+        {:else if !query.trim()}
+          <p class="status">
+            Type to search across docs, recipes, and the full API reference.
+          </p>
+        {:else}
+          <ul class="hits">
+            {#each hits as hit (hit.url)}
+              <li>
+                <a href={hit.url} onclick={closeModal}>
+                  <span class="hit-title">{hit.title}</span>
+                  <span class="hit-excerpt">{@html hit.excerpt}</span>
+                </a>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.32rem 0.55rem 0.32rem 0.7rem;
+    background: var(--bg-soft);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--fg-muted);
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition:
+      color 120ms ease,
+      border-color 120ms ease;
+  }
+
+  .trigger:hover {
+    color: var(--fg);
+    border-color: var(--accent-soft);
+  }
+
+  .trigger-kbd {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    font-weight: 500;
+    color: var(--fg-muted);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 0 5px;
+    background: var(--bg);
+  }
+
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background: color-mix(in oklab, black 55%, transparent);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 6vh 1rem 1rem;
+  }
+
+  .modal {
+    width: min(640px, 100%);
+    max-height: calc(100vh - 8vh);
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 24px 60px -20px rgba(0, 0, 0, 0.6);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .input-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .input {
+    flex: 1;
+    appearance: none;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--fg);
+    font-family: inherit;
+    font-size: 0.98rem;
+    padding: 0.2rem 0;
+  }
+
+  .input::placeholder {
+    color: var(--fg-muted);
+  }
+
+  .esc {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--fg-muted);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 0 5px;
+  }
+
+  .results {
+    overflow-y: auto;
+    max-height: calc(100vh - 14vh);
+  }
+
+  .status {
+    color: var(--fg-muted);
+    font-size: 0.9rem;
+    margin: 0;
+    padding: 1.4rem 1rem;
+    text-align: center;
+  }
+
+  .status code {
+    font-family: var(--mono);
+    background: var(--bg-soft);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+  }
+
+  .hits {
+    list-style: none;
+    padding: 0.4rem 0.4rem 0.6rem;
+    margin: 0;
+  }
+
+  .hits li a {
+    display: block;
+    padding: 0.55rem 0.65rem;
+    border-radius: var(--radius-sm);
+    color: var(--fg);
+    text-decoration: none;
+    line-height: 1.35;
+  }
+
+  .hits li a:hover,
+  .hits li a:focus-visible {
+    background: var(--bg-soft);
+    outline: none;
+  }
+
+  .hit-title {
+    display: block;
+    font-weight: 600;
+    font-size: 0.95rem;
+    margin-bottom: 0.15rem;
+  }
+
+  .hit-excerpt {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--fg-soft);
+  }
+
+  .hit-excerpt :global(mark) {
+    background: var(--accent-soft);
+    color: var(--fg);
+    padding: 0 0.1em;
+    border-radius: 2px;
+  }
+
+  @media (max-width: 640px) {
+    .trigger-label {
+      display: none;
+    }
+
+    .trigger-kbd {
+      display: none;
+    }
+
+    .trigger {
+      padding: 0.32rem 0.5rem;
+    }
+
+    .trigger::after {
+      content: '🔍';
+      font-size: 13px;
+    }
+  }
+</style>

--- a/site/src/lib/components/Search.svelte
+++ b/site/src/lib/components/Search.svelte
@@ -67,10 +67,19 @@
     if (q !== query) return; // a newer keystroke landed; drop stale results
     const top = await Promise.all(search.results.slice(0, 10).map((r) => r.data()));
     hits = top.map((d) => ({
-      url: d.url,
+      url: normalizeRouteUrl(d.url),
       title: d.meta.title ?? d.url,
       excerpt: d.excerpt,
     }));
+  }
+
+  // Pagefind records the on-disk file path it indexed (e.g.
+  // `/docs/streaming.html`), but SvelteKit's dev/preview servers only
+  // resolve the canonical route (`/docs/streaming`). Strip the `.html`
+  // suffix so result links work in dev and on the deployed static host
+  // alike.
+  function normalizeRouteUrl(url: string): string {
+    return url.replace(/\/index\.html(?=$|\?|#)/, '/').replace(/\.html(?=$|\?|#)/, '');
   }
 
   $effect(() => {

--- a/site/src/lib/components/Sidebar.svelte
+++ b/site/src/lib/components/Sidebar.svelte
@@ -4,7 +4,7 @@
   import { docSections } from '$lib/docs-nav';
 </script>
 
-<aside class="sidebar">
+<aside class="sidebar" data-pagefind-ignore>
   <nav>
     {#each docSections as section, sIdx (section.title)}
       <section>

--- a/site/src/lib/components/SiteHeader.svelte
+++ b/site/src/lib/components/SiteHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { base } from '$app/paths';
   import { page } from '$app/state';
+  import Search from './Search.svelte';
 
   const links: Array<{ path: string; label: string; external?: boolean }> = [
     { path: '/docs/getting-started', label: 'Docs' },
@@ -19,7 +20,7 @@
   }
 </script>
 
-<header class="site-header">
+<header class="site-header" data-pagefind-ignore>
   <div class="inner">
     <a href="{base}/" class="brand">
       <img src="{base}/logo.png" alt="" class="brand-mark" width="32" height="32" />
@@ -39,6 +40,7 @@
           {#if link.external}<span class="nav-arrow">↗</span>{/if}
         </a>
       {/each}
+      <Search />
     </nav>
   </div>
 </header>

--- a/site/src/routes/api/[section]/+page.svelte
+++ b/site/src/routes/api/[section]/+page.svelte
@@ -20,7 +20,7 @@
     </p>
   </header>
 
-  <nav class="toc" aria-label="On this page">
+  <nav class="toc" aria-label="On this page" data-pagefind-ignore>
     <h4>On this page</h4>
     {#each data.subgroups as group (group.id)}
       <div class="toc-group">

--- a/site/src/routes/docs/recipes/+page.svelte
+++ b/site/src/routes/docs/recipes/+page.svelte
@@ -27,7 +27,7 @@
     </p>
   </header>
 
-  <nav class="toc" aria-label="Recipes index">
+  <nav class="toc" aria-label="Recipes index" data-pagefind-ignore>
     <h4>Recipes</h4>
     {#each data.groups as group (group.title)}
       <div class="toc-group">

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,8 +1,73 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, type Connect, type Plugin } from 'vite';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// Pagefind writes its index into `build/pagefind/` AFTER `vite build` has
+// already cataloged the static assets — so SvelteKit's dev/preview
+// middleware doesn't know about those files and 404s requests for them.
+// This middleware serves `/pagefind/**` straight from disk so the site's
+// own `<Search>` component can fetch the index in `pnpm dev` / `pnpm
+// preview` once a production build has been run at least once. On the
+// real static host (GitHub Pages) the directory is served as plain
+// files; this plugin is a local-only convenience.
+function servePagefindFromBuild(): Plugin {
+  const buildPagefind = path.resolve('build/pagefind');
+
+  const handler: Connect.NextHandleFunction = (req, res, next) => {
+    const url = (req.url ?? '').split('?')[0];
+    const match = url.match(/\/pagefind\/(.+)$/);
+    if (!match) return next();
+
+    const rel = match[1];
+    if (!rel) return next();
+
+    const filePath = path.join(buildPagefind, rel);
+    if (!filePath.startsWith(buildPagefind + path.sep)) return next();
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      return next();
+    }
+    if (!stat.isFile()) return next();
+
+    res.setHeader('Content-Type', contentTypeFor(filePath));
+    res.setHeader('Cache-Control', 'no-cache');
+    fs.createReadStream(filePath).pipe(res);
+  };
+
+  return {
+    name: 'serve-pagefind-from-build',
+    configureServer(server) {
+      server.middlewares.use(handler);
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use(handler);
+    },
+  };
+}
+
+function contentTypeFor(p: string): string {
+  switch (path.extname(p).toLowerCase()) {
+    case '.js':
+      return 'application/javascript';
+    case '.json':
+      return 'application/json';
+    case '.wasm':
+      return 'application/wasm';
+    case '.css':
+      return 'text/css';
+    case '.html':
+      return 'text/html';
+    default:
+      return 'application/octet-stream';
+  }
+}
 
 export default defineConfig({
-  plugins: [sveltekit()],
+  plugins: [sveltekit(), servePagefindFromBuild()],
   server: {
     fs: {
       // Allow serving files from the parent project (for example .ts files


### PR DESCRIPTION
## Summary

Adds full-text search across docs, recipes, and the API reference, using
[Pagefind](https://pagefind.app/) as a build-time indexer. Closes #34.

### Build pipeline

- `pagefind ^1.4` added to `site/devDependencies`
- `site` `build` script: `vite build && pagefind --site build`
- Pagefind walks `build/` for HTML and writes `build/pagefind/`
- `deploy-site.yml` already uploads `site/build` as the Pages artifact,
  so the indexer output ships automatically — no CI change required

### Search UI

- New \`site/src/lib/components/Search.svelte\`
- Trigger lives in \`SiteHeader\` to the right of nav
- Keyboard: \`Cmd\` / \`Ctrl\` + \`K\` to open, \`/\` to open from any
  non-typing focus, \`Esc\` to close
- Modal overlay with input + result list
- Lazy-loads \`/<base>/pagefind/pagefind.js\` on first interaction;
  visitors who never search pay zero
- Falls back to "Search index not available" in \`vite dev\` (the
  indexer only runs on production build)

### Index hygiene

\`data-pagefind-ignore\` markers on:
- \`SiteHeader\` (whole header — nav + brand + search itself)
- \`Sidebar\` (docs sidebar nav)
- Recipes page TOC
- API section page TOC

So results land on actual content, not chrome.

## Verification

- \`pnpm --filter xlsx-kit-site check\` — 0 errors / 0 warnings (485 files)
- \`pnpm --filter xlsx-kit-site build\` — succeeds
- Pagefind output: indexed 23 pages, 4716 words; \`build/pagefind/\`
  ~900 KB total

### Bundle / payload impact

| | Before | After | Note |
|---|---|---|---|
| Published \`xlsx-kit\` lib | unchanged | unchanged | site-only feature |
| Site Vite bundle | unchanged | + ~3 KB gzip | Search.svelte itself |
| Pages artifact | 5.4 MB | 6.3 MB | adds build/pagefind/ |
| First-search payload | 0 | ~160 KB | pagefind.js + worker + wasm, loaded on demand |

The 900 KB pagefind directory includes prebuilt UI bundles
(\`pagefind-ui.*\`, \`pagefind-modular-ui.*\`, \`pagefind-component-ui.*\`)
that we don't load — total payload at first search is ~160 KB. We
could prune those with a post-build step if budget tightens; deferring
that until it matters.

## Test plan

Cannot validate the full UX in CI; needs a manual pass:

- [ ] After merge, visit
      \`https://baseballyama.github.io/xlsx-kit/\` and confirm the
      \`Search\` button appears in the header
- [ ] Press \`Cmd\` / \`Ctrl\` + \`K\`; modal opens and input is focused
- [ ] Press \`/\` from a non-input focus; modal opens
- [ ] Type \`iterRows\` → top results include the Worksheet API entry
      and the streaming-read recipe (issue #34's acceptance test)
- [ ] Type \`Date\` → results span Cells / Coordinates / Styles
      sections (#34's acceptance test)
- [ ] Click a result → navigates and closes the modal
- [ ] Press \`Esc\` → modal closes
- [ ] On mobile width (\`< 640px\`): trigger collapses to icon only
- [ ] Sidebar / TOC text does NOT appear in results (the
      \`data-pagefind-ignore\` markers are working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)