### PR TITLE
fix(streaming): apply full sheet-title rules in write-only path

### DIFF
--- a/.changeset/streaming-sheet-name-validation.md
+++ b/.changeset/streaming-sheet-name-validation.md
@@ -1,0 +1,5 @@
+---
+'xlsx-kit': patch
+---
+
+Tighten sheet-title validation on the streaming write path. The `createWriteOnlyWorkbook` `addWorksheet` call now applies the same rules as the buffered `addWorksheet` (no `: \ / ? * [ ]`, no leading / trailing apostrophe, not the reserved name `History`) and rejects duplicate titles case-insensitively so the streaming path can't produce a workbook Excel refuses to open.

--- a/src/streaming/write-only.ts
+++ b/src/streaming/write-only.ts
@@ -32,6 +32,7 @@ import type { Font } from '../styles/fonts';
 import type { Protection } from '../styles/protection';
 import { OpenXmlIoError } from '../utils/exceptions';
 import { makeSharedStrings, sharedStringsToBytes } from '../workbook/shared-strings';
+import { validateSheetTitle } from '../workbook/workbook';
 import { serializeCell } from '../worksheet/writer';
 import {
   ARC_CONTENT_TYPES,
@@ -84,10 +85,11 @@ export interface WriteOnlyWorkbook {
 }
 
 const validateTitle = (title: string, taken: Set<string>): void => {
-  if (typeof title !== 'string' || title.length === 0 || title.length > 31) {
-    throw new OpenXmlIoError(`Worksheet title must be 1..31 chars; got "${title}"`);
+  const reason = validateSheetTitle(title);
+  if (reason) {
+    throw new OpenXmlIoError(`Worksheet title "${title}": ${reason}`);
   }
-  if (taken.has(title)) {
+  if (taken.has(title.toLowerCase())) {
     throw new OpenXmlIoError(`Worksheet title "${title}" is already in use`);
   }
 };
@@ -284,7 +286,7 @@ const makeWriteOnlyWorkbook = (sink: XlsxSink): WriteOnlyWorkbook => {
         'addWorksheet: previous worksheet still open — call close() before opening the next one',
       );
     }
-    const taken = new Set(state.sheets.map((s) => s.title));
+    const taken = new Set(state.sheets.map((s) => s.title.toLowerCase()));
     validateTitle(title, taken);
     state.hasOpenWorksheet = true;
     const sheetId = state.sheets.length + 1;

--- a/tests/streaming/write-only.test.ts
+++ b/tests/streaming/write-only.test.ts
@@ -109,6 +109,41 @@ describe('createWriteOnlyWorkbook — sequencing constraints', () => {
     await a.close();
     await expect(wb.addWorksheet('Same')).rejects.toThrowError(/already in use/);
   });
+
+  it('rejects duplicate worksheet titles case-insensitively', async () => {
+    const sink = toBuffer();
+    const wb = await createWriteOnlyWorkbook(sink);
+    const a = await wb.addWorksheet('Data');
+    await a.close();
+    await expect(wb.addWorksheet('data')).rejects.toThrowError(/already in use/);
+    await expect(wb.addWorksheet('DATA')).rejects.toThrowError(/already in use/);
+  });
+
+  it('rejects forbidden characters in the title', async () => {
+    const sink = toBuffer();
+    const wb = await createWriteOnlyWorkbook(sink);
+    await expect(wb.addWorksheet('Bad/Name')).rejects.toThrowError(/must not contain/);
+    await expect(wb.addWorksheet('Bad\\Name')).rejects.toThrowError(/must not contain/);
+    await expect(wb.addWorksheet('Bad:Name')).rejects.toThrowError(/must not contain/);
+    await expect(wb.addWorksheet('Bad?Name')).rejects.toThrowError(/must not contain/);
+    await expect(wb.addWorksheet('Bad*Name')).rejects.toThrowError(/must not contain/);
+    await expect(wb.addWorksheet('Bad[1]')).rejects.toThrowError(/must not contain/);
+  });
+
+  it('rejects leading or trailing apostrophe in the title', async () => {
+    const sink = toBuffer();
+    const wb = await createWriteOnlyWorkbook(sink);
+    await expect(wb.addWorksheet("'Leading")).rejects.toThrowError(/apostrophe/);
+    await expect(wb.addWorksheet("Trailing'")).rejects.toThrowError(/apostrophe/);
+  });
+
+  it('rejects the reserved name "History" case-insensitively', async () => {
+    const sink = toBuffer();
+    const wb = await createWriteOnlyWorkbook(sink);
+    await expect(wb.addWorksheet('History')).rejects.toThrowError(/reserved/);
+    await expect(wb.addWorksheet('history')).rejects.toThrowError(/reserved/);
+    await expect(wb.addWorksheet('HISTORY')).rejects.toThrowError(/reserved/);
+  });
 });
 
 describe('createWriteOnlyWorkbook — styles + sharedStrings', () => {


### PR DESCRIPTION
## Summary
- The streaming write-only `addWorksheet` only checked length and an exact-match duplicate, so it accepted titles like `Bad/Name`, leading/trailing apostrophes, and `History` that the buffered API correctly rejects.
- It also compared duplicates with `===`, so `Data` and `data` could co-exist — Excel treats sheet names as case-insensitive and would refuse the resulting workbook.
- Routed the streaming path through `validateSheetTitle` and lowered both sides of the duplicate check.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (2250 passed, including new coverage for `/`, `\`, `:`, `?`, `*`, `[`, `]`, leading/trailing `'`, `History`, and case-insensitive duplicates on the streaming path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)