### PR TITLE
fix(workbook): treat sheet names as case-insensitive for uniqueness

### DIFF
--- a/.changeset/case-insensitive-sheet-uniqueness.md
+++ b/.changeset/case-insensitive-sheet-uniqueness.md
@@ -1,0 +1,5 @@
+---
+'xlsx-kit': patch
+---
+
+Treat sheet names as case-insensitive for uniqueness, matching Excel. Previously `addWorksheet(wb, 'Data')` followed by `addWorksheet(wb, 'data')` succeeded locally but produced a workbook Excel and LibreOffice refuse to open. `addWorksheet`, `addChartsheet`, `duplicateSheet`, `renameSheet`, and `pickUniqueSheetTitle` now compare titles case-insensitively. A case-only rename of the same sheet (`renameSheet(wb, 'Data', 'data')`) is allowed.

--- a/src/workbook/workbook.ts
+++ b/src/workbook/workbook.ts
@@ -231,6 +231,9 @@ export const isValidSheetTitle = (title: unknown): title is string => validateSh
  * validateSheetTitle} — if the base+suffix would exceed 31 chars, the base is
  * truncated to fit.
  *
+ * Excel treats sheet names as case-insensitive for uniqueness, so `Data` and
+ * `data` collide; the helper applies the same rule.
+ *
  * Useful for "duplicate sheet" / "import" flows where you want Excel-like
  * automatic uniqueification ("Sheet1 (2)").
  */
@@ -240,25 +243,31 @@ export function pickUniqueSheetTitle(wb: Workbook, base: string): string {
     throw new OpenXmlSchemaError(`pickUniqueSheetTitle: base "${base}" is not a valid sheet title (${reason})`);
   }
   const used = new Set<string>();
-  for (const s of wb.sheets) used.add(s.sheet.title);
-  if (!used.has(base)) return base;
+  for (const s of wb.sheets) used.add(s.sheet.title.toLowerCase());
+  if (!used.has(base.toLowerCase())) return base;
   for (let n = 2; n < 1000; n++) {
     const suffix = ` (${n})`;
     const room = 31 - suffix.length;
     const truncatedBase = base.length > room ? base.slice(0, room) : base;
     const candidate = `${truncatedBase}${suffix}`;
-    if (!used.has(candidate)) return candidate;
+    if (!used.has(candidate.toLowerCase())) return candidate;
   }
   throw new OpenXmlSchemaError(`pickUniqueSheetTitle: exhausted candidates for "${base}"`);
 }
 
-const validateUniqueTitle = (wb: Workbook, title: string): void => {
+// Excel treats sheet names as case-insensitive for uniqueness — "Data" and
+// "data" cannot co-exist in the same workbook. `ignoreIndex` lets renameSheet
+// pass its own slot so a case-only rename ("Data" → "data") still succeeds.
+const validateUniqueTitle = (wb: Workbook, title: string, ignoreIndex?: number): void => {
   const reason = validateSheetTitle(title);
   if (reason) {
     throw new OpenXmlSchemaError(`Worksheet title "${title}": ${reason}`);
   }
-  for (const s of wb.sheets) {
-    if (s.sheet.title === title) {
+  const lower = title.toLowerCase();
+  for (let i = 0; i < wb.sheets.length; i++) {
+    if (i === ignoreIndex) continue;
+    const s = wb.sheets[i];
+    if (s && s.sheet.title.toLowerCase() === lower) {
       throw new OpenXmlSchemaError(`Worksheet title "${title}" is already in use`);
     }
   }
@@ -460,15 +469,12 @@ export function setActiveSheet(wb: Workbook, title: string): void {
  * sheet names to be unique within a workbook).
  */
 export function renameSheet(wb: Workbook, oldTitle: string, newTitle: string): void {
-  if (typeof newTitle !== 'string' || newTitle.length === 0) {
-    throw new OpenXmlSchemaError('renameSheet: newTitle must be a non-empty string');
-  }
   const i = wb.sheets.findIndex((s) => s.sheet.title === oldTitle);
   if (i < 0) throw new OpenXmlSchemaError(`renameSheet: no sheet named "${oldTitle}"`);
   if (oldTitle === newTitle) return;
-  if (wb.sheets.some((s) => s.sheet.title === newTitle)) {
-    throw new OpenXmlSchemaError(`renameSheet: a sheet named "${newTitle}" already exists`);
-  }
+  // Excel allows case-only renames ("Data" → "data"); ignore the current slot
+  // when checking uniqueness so the rename validates against everything else.
+  validateUniqueTitle(wb, newTitle, i);
   const ref = wb.sheets[i];
   if (ref) ref.sheet.title = newTitle;
 }

--- a/tests/workbook/sheet-name-case-insensitivity.test.ts
+++ b/tests/workbook/sheet-name-case-insensitivity.test.ts
@@ -1,0 +1,48 @@
+// Excel treats sheet names as case-insensitive for uniqueness — "Data" and
+// "data" cannot co-exist in the same workbook. These tests pin that behavior
+// down for addWorksheet / addChartsheet / pickUniqueSheetTitle so regressions
+// don't quietly produce workbooks Excel refuses to open.
+
+import { describe, expect, it } from 'vitest';
+import {
+  addChartsheet,
+  addWorksheet,
+  createWorkbook,
+  duplicateSheet,
+  pickUniqueSheetTitle,
+} from '../../src/workbook/workbook';
+
+describe('sheet name uniqueness — case-insensitive', () => {
+  it('addWorksheet rejects a title that differs only in case', () => {
+    const wb = createWorkbook();
+    addWorksheet(wb, 'Data');
+    expect(() => addWorksheet(wb, 'data')).toThrow(/already in use/);
+    expect(() => addWorksheet(wb, 'DATA')).toThrow(/already in use/);
+    expect(() => addWorksheet(wb, 'DaTa')).toThrow(/already in use/);
+  });
+
+  it('addChartsheet collides with a worksheet of the same name in a different case', () => {
+    const wb = createWorkbook();
+    addWorksheet(wb, 'Charts');
+    expect(() => addChartsheet(wb, 'charts')).toThrow(/already in use/);
+  });
+
+  it('addWorksheet collides with a chartsheet of the same name in a different case', () => {
+    const wb = createWorkbook();
+    addChartsheet(wb, 'Charts');
+    expect(() => addWorksheet(wb, 'charts')).toThrow(/already in use/);
+  });
+
+  it('pickUniqueSheetTitle picks the next slot when only a case variant exists', () => {
+    const wb = createWorkbook();
+    addWorksheet(wb, 'Data');
+    expect(pickUniqueSheetTitle(wb, 'DATA')).toBe('DATA (2)');
+    expect(pickUniqueSheetTitle(wb, 'data')).toBe('data (2)');
+  });
+
+  it('duplicateSheet rejects a target that differs only in case', () => {
+    const wb = createWorkbook();
+    addWorksheet(wb, 'Data');
+    expect(() => duplicateSheet(wb, 'Data', 'data')).toThrow(/already in use/);
+  });
+});

--- a/tests/workbook/sheet-rename-move.test.ts
+++ b/tests/workbook/sheet-rename-move.test.ts
@@ -44,6 +44,22 @@ describe('renameSheet', () => {
     renameSheet(wb, 'A', 'A');
     expect(sheetNames(wb)).toEqual(['A']);
   });
+
+  it('rejects duplicate target case-insensitively', () => {
+    const wb = createWorkbook();
+    addWorksheet(wb, 'Alpha');
+    addWorksheet(wb, 'Beta');
+    expect(() => renameSheet(wb, 'Alpha', 'BETA')).toThrow(/already in use/);
+    expect(() => renameSheet(wb, 'Alpha', 'beta')).toThrow(/already in use/);
+  });
+
+  it('allows a case-only rename of the same sheet', () => {
+    const wb = createWorkbook();
+    addWorksheet(wb, 'Data');
+    addWorksheet(wb, 'Other');
+    renameSheet(wb, 'Data', 'DATA');
+    expect(sheetNames(wb)).toEqual(['DATA', 'Other']);
+  });
 });
 
 describe('moveSheet', () => {


### PR DESCRIPTION
## Summary
- Excel rejects workbooks containing two sheets that differ only in case (`Data` + `data`), but `addWorksheet` / `addChartsheet` / `duplicateSheet` / `renameSheet` / `pickUniqueSheetTitle` all compared titles with `===` — so the broken state would only surface when the user opened the resulting file in Excel or LibreOffice.
- Switched the uniqueness check (and `pickUniqueSheetTitle`'s suffix probe) to `toLowerCase()` comparison.
- `renameSheet` now allows case-only renames of the same sheet (`Data` → `data`) by ignoring the source slot during the duplicate check.
- Lookups (`getSheet`, `hasSheet`, etc.) stay case-sensitive — only uniqueness changes.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (2257 passed; new `tests/workbook/sheet-name-case-insensitivity.test.ts` plus the existing rename suite cover the new behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)