### PR TITLE
docs(zip64): note the 4 GiB-per-entry limit alongside the entry-count win

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ paywall.
 - You produce **large** xlsx files (tens of millions of cells) and care
   about heap budget.
 - You need **charts**, conditional formatting, data validation, defined
-  names, tables, ZIP64 — and want them in MIT.
+  names, tables, ZIP64 (entry-count overflow; see "What's supported" for the
+  4 GiB-per-entry caveat) — and want them in MIT.
 - You round-trip xlsx files that contain pivot tables, VBA macros,
   threaded comments, Power Query metadata, or customXml — and need them
   preserved byte-for-byte.
@@ -261,8 +262,14 @@ band queries reuse the cached index.
   extras and per-sheet rels chain are preserved end-to-end.
 - ✅ Encrypted xlsx detection (CFB Compound Document magic): clear error
   pointing at `msoffcrypto-tool` for decryption.
-- ✅ ZIP64 write: workbooks with > 65 535 entries get a ZIP64 EOCD record +
-  locator spliced into the final chunk. Read works too.
+- ✅ ZIP64 write — partial: workbooks with > 65 535 entries get a ZIP64 EOCD
+  record + locator spliced into the final chunk. Read works too. **Limit:**
+  individual entry sizes and the central-directory offset must still fit in
+  32 bits (≤ 4 GiB each); xlsx archives never approach that in practice, but
+  if you genuinely need a single >4 GiB entry the writer will throw. Tracked
+  in [`src/zip/zip64-patch.ts`][zip64-patch].
+
+[zip64-patch]: ./src/zip/zip64-patch.ts
 
 ## Development
 

--- a/src/zip/writer.ts
+++ b/src/zip/writer.ts
@@ -8,9 +8,16 @@
 // ZIP64 (entry count > 65535): fflate's `Zip` emits a plain ZIP32 EOCD in all
 // cases, so on finalize we splice in a ZIP64 EOCD record + locator when needed
 // via `applyZip64EntryCountPatch`. That keeps the per-entry LFH/CDH layout
-// fflate produces (correct as long as no individual size or offset overflows 32
-// bits) and only rewrites the trailing records — enough for xlsx, which never
-// approaches single-entry 4 GiB limits.
+// fflate produces and only rewrites the trailing records.
+//
+// Scope: this covers the entry-count-overflow case (the limit xlsx archives
+// realistically hit — `tens of millions of cells` → tens of thousands of
+// worksheet entries via the streaming writer). Per-entry compressed/uncompressed
+// sizes and the central-directory offset must still fit in 32 bits (≤ 4 GiB
+// each); a single >4 GiB entry would need full ZIP64 size support and
+// `applyZip64EntryCountPatch` throws `OpenXmlNotImplementedError` if we ever
+// detect that. xlsx workbooks don't approach that limit in practice, but the
+// constraint is real — surface it in your own size estimates.
 
 import { Zip, ZipDeflate, ZipPassThrough } from 'fflate';
 import type { XlsxSink } from '../io/sink';


### PR DESCRIPTION
## Summary
- The README sold ZIP64 as a flat capability and `tens of millions of cells` as a use case, but the current writer only patches the entry-count overflow.
- Per-entry compressed/uncompressed sizes and the central-directory offset must still fit in 32 bits (≤ 4 GiB each); a >4 GiB entry trips `OpenXmlNotImplementedError` in `applyZip64EntryCountPatch`.
- Spelled the constraint out in the "What's supported" entry, the "Why" home-turf bullet, and the writer-level header comment.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- Docs-only; no test changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)