### PR TITLE
fix(io): drop silent no-op LoadOptions fields

### DIFF
--- a/.changeset/remove-noop-load-options.md
+++ b/.changeset/remove-noop-load-options.md
@@ -1,0 +1,5 @@
+---
+'xlsx-kit': minor
+---
+
+Remove the silently-ignored `readOnly` / `keepLinks` / `keepVba` / `dataOnly` / `richText` placeholders from `LoadOptions`. They were declared on the public surface but the loader (`src/io/load.ts`) accepted them via `_opts` and dropped them on the floor, so production callers expecting `dataOnly: true` to suppress formulas — or `readOnly: true` to enable a special path — got the default behaviour instead. `LoadOptions` is now an empty type until the underlying behaviour ships; future toggles will land here once they actually do something. The `loadWorkbook(source, opts)` signature is unchanged.

--- a/src/io/load.ts
+++ b/src/io/load.ts
@@ -49,19 +49,13 @@ import { parseXml } from '../xml/parser';
 import { findChild, findChildren, type XmlNode } from '../xml/tree';
 import { openZip, type ZipArchive } from '../zip/reader';
 
-/** Options for {@link loadWorkbook}. The full surface lands in later iterations. */
-export interface LoadOptions {
-  /** Reserved — not yet implemented. */
-  readOnly?: boolean;
-  /** Reserved — not yet implemented. */
-  keepLinks?: boolean;
-  /** Reserved — not yet implemented. */
-  keepVba?: boolean;
-  /** Reserved — not yet implemented. */
-  dataOnly?: boolean;
-  /** Reserved — not yet implemented. */
-  richText?: boolean;
-}
+/**
+ * Options for {@link loadWorkbook}. Currently empty — earlier drafts exposed
+ * `readOnly` / `keepLinks` / `keepVba` / `dataOnly` / `richText` placeholders
+ * that the loader silently ignored. They were removed to keep the surface
+ * honest; future toggles will land here once their behavior is implemented.
+ */
+export type LoadOptions = Record<string, never>;
 
 /** Office Document relationship type — the package-root pointer to `xl/workbook.xml`. */
 const OFFICE_DOC_REL_TYPE = `${REL_NS}/officeDocument`;


### PR DESCRIPTION
## Summary
- `LoadOptions` declared `readOnly` / `keepLinks` / `keepVba` / `dataOnly` / `richText` on the public surface, but `loadWorkbook` took the argument as `_opts` and dropped it on the floor — production callers expecting `dataOnly: true` to suppress formulas got the default behaviour instead.
- Removed the misleading fields. `LoadOptions` is now an empty type so future toggles can land here once they actually do something.
- `loadWorkbook(source, opts)` signature is unchanged; passing an empty object (or omitting the argument) continues to work. Passing one of the removed fields now fails to typecheck — which is the desired outcome, since it was silently broken anyway.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm test` (2257 passed; no tests passed options to `loadWorkbook`, so nothing else needed updating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)