### PR TITLE
test(conformance): flag case-insensitive sheet-name collisions

### DIFF
--- a/tests/conformance/smoke.test.ts
+++ b/tests/conformance/smoke.test.ts
@@ -118,4 +118,29 @@ describe('conformance: validator detects deliberately broken xlsx', () => {
     expect(result.ok).toBe(false);
     expect(result.issues.some((i) => i.tier === 'xsd')).toBe(true);
   });
+
+  it('rejects two <sheet> elements that differ only in case', async () => {
+    // Hand-craft the broken workbook bytes instead of going through
+    // addWorksheet, since the typed API now rejects this case-insensitively at
+    // the source. The validator must catch the same break in already-written
+    // bytes (e.g. files produced before that fix landed, or by other tools).
+    const decoder = new TextDecoder();
+    const encoder = new TextEncoder();
+    const wb = createWorkbook();
+    addWorksheet(wb, 'Data');
+    addWorksheet(wb, 'Other');
+    const original = await workbookToBytes(wb);
+    const entries = unzipSync(original);
+    const workbookXml = decoder.decode(entries['xl/workbook.xml']);
+    const broken = workbookXml.replace(/name="Other"/, 'name="data"');
+    entries['xl/workbook.xml'] = encoder.encode(broken);
+    const bytes = zipSync(entries);
+    const result = await validateXlsx(bytes, { skipXsd: true });
+    expect(result.ok).toBe(false);
+    expect(
+      result.issues.some(
+        (i) => i.tier === 'semantic' && /case-insensitive collision/.test(i.message),
+      ),
+    ).toBe(true);
+  });
 });

--- a/tests/conformance/validate.ts
+++ b/tests/conformance/validate.ts
@@ -532,24 +532,55 @@ function checkWorkbook(
   relsByPath: Map<string, Relationships>,
   issues: ValidationIssue[],
 ): void {
-  const sheetRe = /<sheet\b[^>]*\bsheetId="(\d+)"[^>]*\br:id="([^"]+)"/g;
-  const altSheetRe = /<sheet\b[^>]*\br:id="([^"]+)"[^>]*\bsheetId="(\d+)"/g;
+  // Walk every `<sheet …/>` opening tag and pick out name / sheetId / r:id from
+  // the attribute soup. Attribute order in OOXML is not fixed, so we can't rely
+  // on positional regexes; instead match the tag boundary once and parse attrs
+  // with a separate scan.
+  const sheetTagRe = /<sheet\b([^>]*)\/?>/g;
+  const attrRe = /\b(name|sheetId|r:id)="([^"]*)"/g;
   const seenSheetIds = new Set<number>();
   const referencedRids = new Set<string>();
-  let m: RegExpExecArray | null;
-  while ((m = sheetRe.exec(xml))) {
-    const sid = Number(m[1]);
-    if (seenSheetIds.has(sid)) {
-      issues.push({ tier: 'semantic', part: path, message: `duplicate sheetId=${sid}` });
+  // Excel treats sheet names as case-insensitive for uniqueness, so a workbook
+  // with both `Data` and `data` is broken even if the XSD accepts it. Track
+  // lower-cased names too.
+  const seenNamesLower = new Map<string, string>();
+  let tag: RegExpExecArray | null;
+  while ((tag = sheetTagRe.exec(xml))) {
+    const attrs = tag[1] ?? '';
+    let name: string | undefined;
+    let sheetIdAttr: string | undefined;
+    let rId: string | undefined;
+    attrRe.lastIndex = 0;
+    let a: RegExpExecArray | null;
+    while ((a = attrRe.exec(attrs))) {
+      if (a[1] === 'name') name = a[2];
+      else if (a[1] === 'sheetId') sheetIdAttr = a[2];
+      else if (a[1] === 'r:id') rId = a[2];
     }
-    seenSheetIds.add(sid);
-    if (m[2]) referencedRids.add(m[2]);
-  }
-  while ((m = altSheetRe.exec(xml))) {
-    const sid = Number(m[2]);
-    if (seenSheetIds.has(sid)) continue; // already counted by primary regex
-    seenSheetIds.add(sid);
-    if (m[1]) referencedRids.add(m[1]);
+    if (sheetIdAttr !== undefined) {
+      const sid = Number(sheetIdAttr);
+      if (seenSheetIds.has(sid)) {
+        issues.push({ tier: 'semantic', part: path, message: `duplicate sheetId=${sid}` });
+      }
+      seenSheetIds.add(sid);
+    }
+    if (rId !== undefined) referencedRids.add(rId);
+    if (name !== undefined) {
+      const lower = name.toLowerCase();
+      const prior = seenNamesLower.get(lower);
+      if (prior !== undefined) {
+        issues.push({
+          tier: 'semantic',
+          part: path,
+          message:
+            prior === name
+              ? `duplicate <sheet name="${name}">`
+              : `duplicate <sheet name="${name}"> (case-insensitive collision with "${prior}")`,
+        });
+      } else {
+        seenNamesLower.set(lower, name);
+      }
+    }
   }
 
   const wbRelsPath = path.replace(/([^/]+)$/, '_rels/$1.rels');


### PR DESCRIPTION
## Summary
- The workbook checker only walked `sheetId` and `r:id`, so a workbook with both `<sheet name=\"Data\">` and `<sheet name=\"data\">` passed every tier — even though Excel refuses to open it.
- Rewrote the sheet-walk to extract `name` alongside `sheetId` / `r:id` and flag exact duplicates plus case-only collisions on the `name` attribute.
- Added a negative test that hand-crafts a workbook with a case-only collision (the typed API rejects it at the source after #64, so the test mutates the post-write bytes) and asserts the validator catches it.

This closes the CI gap called out alongside #64: the typed API now rejects case-only duplicates, and the conformance validator catches the same break in any bytes that reach the gate.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (2258 passed; new negative test pins the validator behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)