### PR TITLE
fix(dml): harden Fill serializer against missing mods and unknown kind

### DIFF
--- a/.changeset/fill-serializer-hardening.md
+++ b/.changeset/fill-serializer-hardening.md
@@ -1,0 +1,5 @@
+---
+'xlsx-kit': patch
+---
+
+Harden DrawingML `Fill` serializer against two natural mis-uses. (1) Passing a colour without `mods` (e.g. `{ base: { kind: 'srgb', value: 'FF0000' } }` instead of `{ base, mods: [] }`) no longer crashes the chart serializer with `Cannot read properties of undefined (reading 'map')`; the missing modifier list is now treated as empty. (2) Passing a `Fill` with an unknown `kind` (e.g. `'solid'` instead of `'solidFill'`) used to silently emit an empty `<c:spPr></c:spPr>` and lose the caller's styling intent; the serializer now throws `OpenXmlSchemaError` so the mistake surfaces immediately.

--- a/src/drawing/dml/dml-xml.ts
+++ b/src/drawing/dml/dml-xml.ts
@@ -1,5 +1,6 @@
 // DrawingML primitive parse / serialize.
 
+import { OpenXmlSchemaError } from '../../utils/exceptions';
 import { DRAWING_NS, REL_NS } from '../../xml/namespaces';
 import { findChild, findChildren, type XmlNode } from '../../xml/tree';
 import {
@@ -163,7 +164,7 @@ const serializeColorMod = (m: ColorMod): string => {
 };
 
 const serializeColorBase = (c: DmlColorWithMods): string => {
-  const inner = c.mods.map(serializeColorMod).join('');
+  const inner = c.mods?.map(serializeColorMod).join('') ?? '';
   switch (c.base.kind) {
     case 'srgb':
       return `<a:srgbClr val="${c.base.value}">${inner}</a:srgbClr>`;
@@ -528,6 +529,13 @@ export const serializeFill = (f: Fill): string => {
       const fg = f.fgClr ? `<a:fgClr>${serializeColorBase(f.fgClr)}</a:fgClr>` : '';
       const bg = f.bgClr ? `<a:bgClr>${serializeColorBase(f.bgClr)}</a:bgClr>` : '';
       return `<a:pattFill prst="${escapeAttr(f.preset)}">${fg}${bg}</a:pattFill>`;
+    }
+    default: {
+      // Reject a misconstructed Fill at the throw site rather than emitting an
+      // empty wrapper element. Excel happens to accept empty <c:spPr/>, but the
+      // caller's intent is silently dropped and the failure is invisible.
+      const kind = (f as { kind?: unknown }).kind;
+      throw new OpenXmlSchemaError(`serializeFill: unknown Fill.kind ${JSON.stringify(kind)}`);
     }
   }
 };

--- a/tests/drawing/issue-53.test.ts
+++ b/tests/drawing/issue-53.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { serializeFill } from '../../src/drawing/dml/dml-xml';
+import type { Fill } from '../../src/drawing/dml/fill';
+
+describe('issue #53 — DmlColorWithMods.mods omitted does not crash the serializer', () => {
+  it('emits a valid solidFill when the caller forgets to supply `mods: []`', () => {
+    const fill = {
+      kind: 'solidFill' as const,
+      color: { base: { kind: 'srgb' as const, value: 'FF0000' } } as never,
+    } satisfies Fill;
+    const xml = serializeFill(fill);
+    expect(xml).toBe('<a:solidFill><a:srgbClr val="FF0000"></a:srgbClr></a:solidFill>');
+  });
+
+  it('emits a valid gradient stop when mods is missing on a stop colour', () => {
+    const fill: Fill = {
+      kind: 'gradFill',
+      stops: [{ pos: 0, color: { base: { kind: 'srgb', value: '00FF00' } } as never }],
+    };
+    const xml = serializeFill(fill);
+    expect(xml).toContain('<a:srgbClr val="00FF00"></a:srgbClr>');
+  });
+
+  it('emits a valid pattern fill when fgClr/bgClr have no mods', () => {
+    const fill: Fill = {
+      kind: 'pattFill',
+      preset: 'pct50',
+      fgClr: { base: { kind: 'srgb', value: 'AABBCC' } } as never,
+      bgClr: { base: { kind: 'srgb', value: 'DDEEFF' } } as never,
+    };
+    const xml = serializeFill(fill);
+    expect(xml).toContain('<a:srgbClr val="AABBCC"></a:srgbClr>');
+    expect(xml).toContain('<a:srgbClr val="DDEEFF"></a:srgbClr>');
+  });
+});

--- a/tests/drawing/issue-54.test.ts
+++ b/tests/drawing/issue-54.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { serializeFill } from '../../src/drawing/dml/dml-xml';
+import type { Fill } from '../../src/drawing/dml/fill';
+
+describe('issue #54 — malformed Fill kind is not silently dropped', () => {
+  it('throws when serializing a Fill with an unknown kind', () => {
+    // Caller mistypes `kind: 'solid'` instead of `kind: 'solidFill'`. Previously
+    // the serializer silently emitted nothing, producing an empty <c:spPr></c:spPr>
+    // that Excel rendered as the default colour.
+    const bogus = { kind: 'solid', color: { kind: 'srgb', val: 'FF0000' } } as unknown as Fill;
+    expect(() => serializeFill(bogus)).toThrow(/Fill/);
+  });
+});


### PR DESCRIPTION
## Summary

- `serializeColorBase` now tolerates a missing `mods` field on a `DmlColorWithMods` payload, so the natural literal `{ base: { kind: 'srgb', value: 'FF0000' } }` no longer crashes the chart serializer with `Cannot read properties of undefined (reading 'map')`. Callers who go through `makeColor()` are unaffected (it already supplies `mods: []`).
- `serializeFill` now throws `OpenXmlSchemaError` when handed an unknown `Fill.kind` instead of falling through and emitting an empty `<c:spPr></c:spPr>`. The previous behaviour quietly dropped the caller's intent; Excel happened to accept the resulting markup but the chart did not pick up the requested colour.

Closes #53, closes #54.

## Test plan

- [x] \`pnpm vitest run tests/drawing/issue-53.test.ts tests/drawing/issue-54.test.ts\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (full suite — 2262 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)