### PR TITLE
fix(chart): rename NumberFormat to ChartNumberFormat and export it

### DIFF
--- a/.changeset/export-chart-number-format.md
+++ b/.changeset/export-chart-number-format.md
@@ -1,0 +1,5 @@
+---
+'xlsx-kit': patch
+---
+
+Rename the chart-internal `NumberFormat` interface to `ChartNumberFormat` and re-export it from `xlsx-kit/chart`. The interface was already part of the public surface through `AxisShared.numFmt` and `DataLabelList.numFmt`, but the type itself was not exported — callers building axis / data-label options had to write the literal inline. The new name also disambiguates from the cell-stylesheet `NumberFormat` exported from `xlsx-kit/styles`, which is a different shape (`{ numFmtId, formatCode }`). Closes #58.

--- a/src/chart/chart-xml.ts
+++ b/src/chart/chart-xml.ts
@@ -83,7 +83,7 @@ import {
   makeStockChart,
   makeSurface3DChart,
   makeSurfaceChart,
-  type NumberFormat,
+  type ChartNumberFormat,
   type NumericRef,
   type OfPieChart,
   type OfPieType,
@@ -342,7 +342,7 @@ const parseTxPrSlot = (parent: XmlNode): TextBody | undefined => {
 
 const VALID_D_LBL_POS: ReadonlyArray<string> = ['bestFit', 'b', 'ctr', 'inBase', 'inEnd', 'l', 'outEnd', 'r', 't'];
 
-const parseNumberFormat = (el: XmlNode | undefined): NumberFormat | undefined => {
+const parseNumberFormat = (el: XmlNode | undefined): ChartNumberFormat | undefined => {
   if (!el) return undefined;
   const formatCode = el.attrs['formatCode'];
   if (formatCode === undefined) return undefined;
@@ -356,14 +356,14 @@ const parseNumberFormat = (el: XmlNode | undefined): NumberFormat | undefined =>
   return { formatCode, ...(sourceLinked !== undefined ? { sourceLinked } : {}) };
 };
 
-const serializeNumberFormat = (n: NumberFormat): string => {
+const serializeNumberFormat = (n: ChartNumberFormat): string => {
   const sl = n.sourceLinked !== undefined ? ` sourceLinked="${n.sourceLinked ? '1' : '0'}"` : '';
   return `<c:numFmt formatCode="${escapeText(n.formatCode)}"${sl}/>`;
 };
 
 interface DataLabelCommon {
   delete?: boolean;
-  numFmt?: NumberFormat;
+  numFmt?: ChartNumberFormat;
   spPr?: ShapeProperties;
   txPr?: TextBody;
   dLblPos?: DataLabelPosition;
@@ -1333,7 +1333,7 @@ const parseAxisCommon = (
   spPr?: ShapeProperties;
   txPr?: TextBody;
   title?: ChartTitle;
-  numFmt?: NumberFormat;
+  numFmt?: ChartNumberFormat;
   majorTickMark?: TickMark;
   minorTickMark?: TickMark;
   tickLblPos?: TickLabelPosition;

--- a/src/chart/chart.ts
+++ b/src/chart/chart.ts
@@ -45,7 +45,15 @@ export interface CategoryRef {
 
 // ---- Series decorations: data labels, trendlines, error bars --------------
 
-export interface NumberFormat {
+/**
+ * Number-format payload for chart axes / data labels (`<c:numFmt formatCode="…"
+ * sourceLinked="0|1"/>`).
+ *
+ * Named `ChartNumberFormat` to avoid colliding with the cell-stylesheet
+ * `NumberFormat` exported from `xlsx-kit/styles`, which is a different shape
+ * (`{ numFmtId, formatCode }`).
+ */
+export interface ChartNumberFormat {
   formatCode: string;
   sourceLinked?: boolean;
 }
@@ -59,7 +67,7 @@ export interface DataLabel {
   delete?: boolean;
   /** Inline rich text or a cell reference. Mutually exclusive. */
   tx?: { kind: 'rich'; body: TextBody } | { kind: 'strRef'; ref: string };
-  numFmt?: NumberFormat;
+  numFmt?: ChartNumberFormat;
   spPr?: ShapeProperties;
   txPr?: TextBody;
   dLblPos?: DataLabelPosition;
@@ -78,7 +86,7 @@ export interface DataLabelList {
   delete?: boolean;
   /** Per-point overrides. */
   dLbl?: DataLabel[];
-  numFmt?: NumberFormat;
+  numFmt?: ChartNumberFormat;
   spPr?: ShapeProperties;
   txPr?: TextBody;
   dLblPos?: DataLabelPosition;
@@ -493,7 +501,7 @@ interface AxisShared {
   /** Axis title (`<c:title>`). Reuses the chart-title structure. */
   title?: ChartTitle;
   /** Tick-label number format. Default emitted is `General` / `sourceLinked=1`. */
-  numFmt?: NumberFormat;
+  numFmt?: ChartNumberFormat;
   /** Major tick mark style. Default emitted is `out`. */
   majorTickMark?: TickMark;
   /** Minor tick mark style. Default emitted is `none`. */

--- a/src/chart/index.ts
+++ b/src/chart/index.ts
@@ -20,6 +20,7 @@ export type {
   CategoryLabelAlignment,
   CategoryRef,
   ChartKind,
+  ChartNumberFormat,
   ChartSpace,
   ChartTitle,
   DateAxis,

--- a/tests/chart/issue-58.test.ts
+++ b/tests/chart/issue-58.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { ChartNumberFormat, ValueAxis } from '../../src/chart';
+import { makeBarChart, makeBarSeries, makeChartSpace } from '../../src/chart/chart';
+import { chartToBytes } from '../../src/chart/chart-xml';
+
+describe('issue #58 — ChartNumberFormat is publicly importable from xlsx-kit/chart', () => {
+  it('lets a caller name the type used by axis numFmt', () => {
+    const fmt: ChartNumberFormat = { formatCode: '#,##0', sourceLinked: false };
+    const valAx: Partial<ValueAxis> = { numFmt: fmt };
+    expectTypeOf<ChartNumberFormat>().toEqualTypeOf<{ formatCode: string; sourceLinked?: boolean }>();
+    expect(valAx.numFmt?.formatCode).toBe('#,##0');
+  });
+
+  it('round-trips numFmt through the chart serializer', () => {
+    const chart = makeBarChart({
+      series: [makeBarSeries({ idx: 0, val: { ref: 'Sheet1!$B$2:$B$5' } })],
+    });
+    const space = makeChartSpace({
+      plotArea: {
+        chart,
+        catAx: { axId: 1, crossAx: 2 },
+        valAx: {
+          axId: 2,
+          crossAx: 1,
+          numFmt: { formatCode: '#,##0', sourceLinked: false } satisfies ChartNumberFormat,
+        },
+      },
+    });
+    const xml = new TextDecoder().decode(chartToBytes(space));
+    expect(xml).toContain('<c:numFmt formatCode="#,##0" sourceLinked="0"/>');
+  });
+});


### PR DESCRIPTION
## Summary

- Rename the chart-internal \`NumberFormat\` interface to \`ChartNumberFormat\` and re-export it from \`xlsx-kit/chart\`. The interface was already reachable through \`AxisShared.numFmt\` and \`DataLabelList.numFmt\` but the type itself was not exported, so callers had to inline the literal.
- The new name also disambiguates from \`xlsx-kit/styles\`' \`NumberFormat\`, which is the cell-stylesheet shape (\`{ numFmtId, formatCode }\`).

Closes #58.

## Test plan

- [x] \`pnpm vitest run tests/chart/issue-58.test.ts\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (full suite passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)