### PR TITLE
feat(drawing): expose DML colour, fill, and text helpers from xlsx-kit/drawing

### DIFF
--- a/.changeset/expose-dml-color-text-from-drawing.md
+++ b/.changeset/expose-dml-color-text-from-drawing.md
@@ -1,0 +1,5 @@
+---
+'xlsx-kit': minor
+---
+
+Re-export DML colour, fill, and text-body primitives from `xlsx-kit/drawing`. Chart styling reaches `<a:srgbClr>` / `<a:solidFill>` / `<a:bodyPr>…<a:p>…<a:r>` through `ShapeProperties.fill`, `Series.spPr`, `Axis.txPr`, etc., but the building blocks (`DmlColor`, `DmlColorWithMods`, `Fill`, `TextBody`, `TextParagraph`, `RunProperties`, …) and their constructors (`makeColor`, `makeSrgbColor`, `makeSchemeColor`, `makeSolidFill`, `makeTextBody`, `makeParagraph`, `makeRun`, `makeRunProperties`, …) previously had no public home. They now ship as part of `xlsx-kit/drawing` alongside `makeShapeProperties`. Closes #55, closes #56.

--- a/src/drawing/index.ts
+++ b/src/drawing/index.ts
@@ -1,5 +1,10 @@
 // Public surface for drawings (charts/images embedded in a worksheet),
 // anchors, image bytes, and DML shape properties.
+//
+// `xlsx-kit/drawing` doubles as the home for the DML primitives that
+// `ShapeProperties` / `TextBody` are built from — colours, fills, lines,
+// effects, and the rich-text body — so callers building chart styling can
+// import everything from a single subpath.
 
 export type {
   ChartReference,
@@ -30,3 +35,68 @@ export type {
 export { makeOneCellAnchor } from './anchor';
 export type { BlackWhiteMode, ShapeProperties, Transform2D } from './dml/shape-properties';
 export { makeShapeProperties } from './dml/shape-properties';
+
+// ---- DML colours -----------------------------------------------------------
+export type { ColorMod, DmlColor, DmlColorWithMods, SchemeColorName } from './dml/colors';
+export {
+  makeColor,
+  makeSchemeColor,
+  makeSrgbColor,
+  SCHEME_COLOR_NAMES,
+  VALUED_COLOR_MOD_KINDS,
+  VALUELESS_COLOR_MOD_KINDS,
+} from './dml/colors';
+
+// ---- DML fills -------------------------------------------------------------
+export type {
+  Blip,
+  BlipEffect,
+  Fill,
+  GradientLineDir,
+  GradientStop,
+  RelativeRect,
+  TileFill,
+  TileFlip,
+} from './dml/fill';
+export {
+  makeGradientFill,
+  makeNoFill,
+  makePatternFill,
+  makeSolidFill,
+  PRESET_PATTERN_NAMES,
+} from './dml/fill';
+
+// ---- DML text body (used by chart axis / title / legend `txPr`) ------------
+export type {
+  AutoFit,
+  BulletProperties,
+  FontAlign,
+  HyperlinkInfo,
+  ParagraphAlign,
+  ParagraphProperties,
+  RunProperties,
+  TabStop,
+  TextAnchor,
+  TextBody,
+  TextBodyProperties,
+  TextCap,
+  TextFont,
+  TextHorzOverflow,
+  TextListStyle,
+  TextOverflow,
+  TextParagraph,
+  TextRun,
+  TextSpacing,
+  TextStrike,
+  TextUnderline,
+  TextVertical,
+  TextWrap,
+} from './dml/text';
+export {
+  makeBreak,
+  makeParagraph,
+  makeRun,
+  makeRunProperties,
+  makeSimpleTextBody,
+  makeTextBody,
+} from './dml/text';

--- a/tests/drawing/issue-55-56-public-dml-surface.test.ts
+++ b/tests/drawing/issue-55-56-public-dml-surface.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type {
+  ColorMod,
+  DmlColor,
+  DmlColorWithMods,
+  Fill,
+  ParagraphProperties,
+  RunProperties,
+  SchemeColorName,
+  TextBody,
+  TextParagraph,
+  TextRun,
+} from '../../src/drawing';
+import {
+  makeBreak,
+  makeColor,
+  makeGradientFill,
+  makeNoFill,
+  makeParagraph,
+  makePatternFill,
+  makeRun,
+  makeRunProperties,
+  makeSchemeColor,
+  makeSimpleTextBody,
+  makeSolidFill,
+  makeSrgbColor,
+  makeTextBody,
+  PRESET_PATTERN_NAMES,
+  SCHEME_COLOR_NAMES,
+} from '../../src/drawing';
+
+describe('issues #55 + #56 — DML colour + fill + text helpers re-export from xlsx-kit/drawing', () => {
+  it('exposes makeSrgbColor / makeSchemeColor / makeColor as values', () => {
+    const srgb = makeSrgbColor('FF0000');
+    expect(srgb).toEqual({ kind: 'srgb', value: 'FF0000' });
+    const scheme = makeSchemeColor('accent1');
+    expect(scheme).toEqual({ kind: 'schemeClr', value: 'accent1' });
+    const wrapped = makeColor(srgb);
+    expect(wrapped.base).toEqual(srgb);
+    expect(wrapped.mods).toEqual([]);
+  });
+
+  it('exposes the colour type aliases', () => {
+    expectTypeOf<DmlColor>().toMatchTypeOf<{ kind: string }>();
+    expectTypeOf<SchemeColorName>().toMatchTypeOf<string>();
+    const mod: ColorMod = { kind: 'tint', val: 50000 };
+    const wrapped: DmlColorWithMods = { base: makeSrgbColor('00FF00'), mods: [mod] };
+    expect(wrapped.mods[0]?.kind).toBe('tint');
+  });
+
+  it('exposes Fill helpers and shape', () => {
+    const solid = makeSolidFill(makeColor(makeSrgbColor('0000FF')));
+    expect(solid.kind).toBe('solidFill');
+    const none = makeNoFill();
+    expect(none.kind).toBe('noFill');
+    const grad = makeGradientFill({
+      stops: [
+        { pos: 0, color: makeColor(makeSrgbColor('FFFFFF')) },
+        { pos: 100000, color: makeColor(makeSrgbColor('000000')) },
+      ],
+    });
+    expect(grad.kind).toBe('gradFill');
+    const patt = makePatternFill({ preset: 'pct50' });
+    expect(patt.kind).toBe('pattFill');
+    // Type-only assertion: Fill is the discriminated union of fill kinds.
+    const _f: Fill = solid;
+    expect(_f).toBe(solid);
+  });
+
+  it('exposes the preset / scheme constants', () => {
+    expect(SCHEME_COLOR_NAMES.length).toBeGreaterThan(0);
+    expect(PRESET_PATTERN_NAMES.length).toBeGreaterThan(0);
+  });
+
+  it('exposes TextBody / Paragraph / Run helpers and types', () => {
+    const rPr: RunProperties = makeRunProperties({ sz: 900, b: true });
+    expect(rPr.sz).toBe(900);
+    const run: TextRun = makeRun('hello', rPr);
+    expect(run.kind === 'r' && run.t).toBe('hello');
+    const br: TextRun = makeBreak();
+    expect(br.kind).toBe('br');
+    const pPr: ParagraphProperties = { defRPr: rPr };
+    const paragraph: TextParagraph = makeParagraph([run], pPr);
+    expect(paragraph.runs.length).toBe(1);
+    const body: TextBody = makeTextBody([paragraph]);
+    expect(body.paragraphs.length).toBe(1);
+    const simple = makeSimpleTextBody('axis label', rPr);
+    expect(simple.paragraphs[0]?.runs.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

\`xlsx-kit/drawing\` already re-exports \`ShapeProperties\` / \`makeShapeProperties\` but not the DML primitives those shape properties are built from. Callers building chart styling (e.g. \`series.spPr.fill.color\`, \`axis.txPr\`) previously had to inline the literal structure or reach into deep \`src/\` paths that aren't part of the published export map.

This PR exposes the following primitives from \`xlsx-kit/drawing\`:

- **Colours**: \`DmlColor\`, \`DmlColorWithMods\`, \`ColorMod\`, \`SchemeColorName\`, \`makeColor\`, \`makeSrgbColor\`, \`makeSchemeColor\`, \`SCHEME_COLOR_NAMES\`, \`VALUED_COLOR_MOD_KINDS\`, \`VALUELESS_COLOR_MOD_KINDS\`
- **Fills**: \`Fill\`, \`GradientStop\`, \`GradientLineDir\`, \`Blip\`, \`BlipEffect\`, \`TileFill\`, \`TileFlip\`, \`RelativeRect\`, \`makeNoFill\`, \`makeSolidFill\`, \`makeGradientFill\`, \`makePatternFill\`, \`PRESET_PATTERN_NAMES\`
- **Text body**: \`TextBody\`, \`TextBodyProperties\`, \`TextListStyle\`, \`TextParagraph\`, \`TextRun\`, \`RunProperties\`, \`ParagraphProperties\`, \`makeTextBody\`, \`makeParagraph\`, \`makeRun\`, \`makeRunProperties\`, \`makeBreak\`, \`makeSimpleTextBody\` plus all the leaf enums (\`ParagraphAlign\`, \`TextAnchor\`, \`TextCap\`, \`TextStrike\`, …).

These compose with the existing \`ShapeProperties\` / \`series.spPr\` / \`axis.txPr\` slots, so collecting them under \`xlsx-kit/drawing\` keeps the one-home rule (rather than introducing a separate \`xlsx-kit/dml\` subpath).

Closes #55, closes #56.

## Test plan

- [x] \`pnpm vitest run tests/drawing/issue-55-56-public-dml-surface.test.ts\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm knip\`
- [x] \`pnpm test\` (full suite passing)
- [x] \`pnpm build && pnpm size\` (all subpaths within budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)