### PR TITLE
feat(chart): accept rich majorGridlines / minorGridlines with spPr

### DIFF
--- a/.changeset/gridlines-rich-form.md
+++ b/.changeset/gridlines-rich-form.md
@@ -1,0 +1,5 @@
+---
+'xlsx-kit': minor
+---
+
+`AxisShared.majorGridlines` and `AxisShared.minorGridlines` now accept `boolean | Gridlines` instead of just `boolean`. The `Gridlines` shape carries a `ShapeProperties`, so `<c:majorGridlines><c:spPr><a:ln>…</a:ln></c:spPr></c:majorGridlines>` can be emitted to colour / dash / weight the gridline (e.g. corporate-style light grey `D9D9D9`). The plain `true` form keeps emitting `<c:majorGridlines/>` so all existing call sites stay unchanged. Round-trip through `parseChartXml` is preserved for both forms. Closes #57.

--- a/src/chart/chart-xml.ts
+++ b/src/chart/chart-xml.ts
@@ -48,6 +48,7 @@ import {
   type ErrorBars,
   type ErrorBarType,
   type ErrorValType,
+  type Gridlines,
   type GroupingType,
   type Legend,
   type LegendPosition,
@@ -1328,8 +1329,8 @@ const parseAxisCommon = (
   crossAx: number;
   position?: 'b' | 't' | 'l' | 'r';
   delete?: boolean;
-  majorGridlines?: boolean;
-  minorGridlines?: boolean;
+  majorGridlines?: boolean | Gridlines;
+  minorGridlines?: boolean | Gridlines;
   spPr?: ShapeProperties;
   txPr?: TextBody;
   title?: ChartTitle;
@@ -1346,8 +1347,8 @@ const parseAxisCommon = (
   const positionRaw = valAttr(findChild(axEl, AX_POS_TAG));
   const validPos = positionRaw === 'b' || positionRaw === 't' || positionRaw === 'l' || positionRaw === 'r';
   const del = boolVal(findChild(axEl, DELETE_TAG));
-  const majorGridlines = findChild(axEl, MAJOR_GRIDLINES_TAG) !== undefined ? true : undefined;
-  const minorGridlines = findChild(axEl, MINOR_GRIDLINES_TAG) !== undefined ? true : undefined;
+  const majorGridlines = parseGridlines(axEl, MAJOR_GRIDLINES_TAG);
+  const minorGridlines = parseGridlines(axEl, MINOR_GRIDLINES_TAG);
   const spPr = parseSpPrSlot(axEl);
   const txPr = parseTxPrSlot(axEl);
   const titleEl = findChild(axEl, TITLE_TAG);
@@ -1922,6 +1923,20 @@ const serializeSurface3DChart = (chart: Surface3DChart): string => {
 type AxisTag = 'catAx' | 'valAx' | 'dateAx' | 'serAx';
 type AxisLike = CategoryAxis | ValueAxis | DateAxis | SeriesAxis;
 
+const serializeGridlines = (tag: 'c:majorGridlines' | 'c:minorGridlines', g: boolean | Gridlines): string => {
+  // `true` -> self-closing element (Excel default rendering).
+  // Object form with `spPr` -> wrapped element so the line can be styled.
+  if (g === true || g === false || !g.spPr) return `<${tag}/>`;
+  return `<${tag}>${serializeShapeProperties(g.spPr)}</${tag}>`;
+};
+
+const parseGridlines = (parent: XmlNode, tagName: string): boolean | Gridlines | undefined => {
+  const el = findChild(parent, tagName);
+  if (!el) return undefined;
+  const spPr = parseSpPrSlot(el);
+  return spPr ? { spPr } : true;
+};
+
 const serializeAxis = (tag: AxisTag, ax: AxisLike): string => {
   // ECMA-376 sequence inside <c:catAx>/<c:valAx>:
   //   axId, scaling, delete, axPos, majorGridlines?, minorGridlines?, title?,
@@ -1936,8 +1951,8 @@ const serializeAxis = (tag: AxisTag, ax: AxisLike): string => {
     `<c:delete val="${ax.delete ? '1' : '0'}"/>`,
     `<c:axPos val="${ax.position ?? (tag === 'catAx' ? 'b' : 'l')}"/>`,
   ];
-  if (ax.majorGridlines) parts.push('<c:majorGridlines/>');
-  if (ax.minorGridlines) parts.push('<c:minorGridlines/>');
+  if (ax.majorGridlines) parts.push(serializeGridlines('c:majorGridlines', ax.majorGridlines));
+  if (ax.minorGridlines) parts.push(serializeGridlines('c:minorGridlines', ax.minorGridlines));
   if (ax.title) parts.push(serializeChartTitle(ax.title));
   parts.push(
     ax.numFmt

--- a/src/chart/chart.ts
+++ b/src/chart/chart.ts
@@ -506,10 +506,23 @@ interface AxisShared {
   crosses?: AxisCrosses;
   /** `<c:crossesAt val="..."/>`. Numeric cross point on the partner axis. */
   crossesAt?: number;
-  /** Whether to draw major gridlines. */
-  majorGridlines?: boolean;
-  /** Whether to draw minor gridlines. */
-  minorGridlines?: boolean;
+  /**
+   * Major gridlines. `true` keeps Excel's default rendering; pass
+   * `{ spPr }` to override the line colour / width / dash. `false` /
+   * `undefined` omit the element entirely.
+   */
+  majorGridlines?: boolean | Gridlines;
+  /** Minor gridlines. Same shape as {@link AxisShared.majorGridlines}. */
+  minorGridlines?: boolean | Gridlines;
+}
+
+/**
+ * Rich `<c:majorGridlines>` / `<c:minorGridlines>` form. Wraps a
+ * `ShapeProperties` so the gridline line can be styled (e.g. corporate-style
+ * light-grey `D9D9D9`).
+ */
+export interface Gridlines {
+  spPr?: ShapeProperties;
 }
 
 export interface CategoryAxis extends AxisShared {

--- a/src/chart/index.ts
+++ b/src/chart/index.ts
@@ -32,6 +32,7 @@ export type {
   ErrorBars,
   ErrorBarType,
   ErrorValType,
+  Gridlines,
   GroupingType,
   HiLowLines,
   Layout,

--- a/tests/chart/issue-57.test.ts
+++ b/tests/chart/issue-57.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { Gridlines, ValueAxis } from '../../src/chart';
+import { makeBarChart, makeBarSeries, makeChartSpace } from '../../src/chart/chart';
+import { chartToBytes, parseChartXml } from '../../src/chart/chart-xml';
+import { makeColor, makeSrgbColor } from '../../src/drawing/dml/colors';
+import { makeSolidFill } from '../../src/drawing/dml/fill';
+import { makeShapeProperties } from '../../src/drawing/dml/shape-properties';
+
+const decode = (bytes: Uint8Array): string => new TextDecoder().decode(bytes);
+
+describe('issue #57 — majorGridlines / minorGridlines accept the rich `{ spPr }` form', () => {
+  it('keeps the boolean `true` form emitting a self-closing element (back-compat)', () => {
+    const xml = decode(
+      chartToBytes(
+        makeChartSpace({
+          plotArea: {
+            chart: makeBarChart({
+              series: [makeBarSeries({ idx: 0, val: { ref: 'Sheet1!$B$2:$B$5' } })],
+            }),
+            catAx: { axId: 1, crossAx: 2 },
+            valAx: { axId: 2, crossAx: 1, majorGridlines: true, minorGridlines: true },
+          },
+        }),
+      ),
+    );
+    expect(xml).toContain('<c:majorGridlines/>');
+    expect(xml).toContain('<c:minorGridlines/>');
+  });
+
+  it('serialises a styled gridline with <c:spPr> when given the object form', () => {
+    const grid: Gridlines = {
+      spPr: makeShapeProperties({
+        ln: { fill: makeSolidFill(makeColor(makeSrgbColor('D9D9D9'))) },
+      }),
+    };
+    const valAx: ValueAxis = {
+      axId: 2,
+      crossAx: 1,
+      majorGridlines: grid,
+    };
+    const xml = decode(
+      chartToBytes(
+        makeChartSpace({
+          plotArea: {
+            chart: makeBarChart({
+              series: [makeBarSeries({ idx: 0, val: { ref: 'Sheet1!$B$2:$B$5' } })],
+            }),
+            catAx: { axId: 1, crossAx: 2 },
+            valAx,
+          },
+        }),
+      ),
+    );
+    expect(xml).toContain('<c:majorGridlines><c:spPr');
+    expect(xml).toContain('<a:srgbClr val="D9D9D9">');
+    expect(xml).toContain('</c:majorGridlines>');
+  });
+
+  it('round-trips both forms through parseChartXml', () => {
+    const grid: Gridlines = {
+      spPr: makeShapeProperties({
+        ln: { fill: makeSolidFill(makeColor(makeSrgbColor('AAAAAA'))) },
+      }),
+    };
+    const space = makeChartSpace({
+      plotArea: {
+        chart: makeBarChart({
+          series: [makeBarSeries({ idx: 0, val: { ref: 'Sheet1!$B$2:$B$5' } })],
+        }),
+        catAx: { axId: 1, crossAx: 2, minorGridlines: true },
+        valAx: { axId: 2, crossAx: 1, majorGridlines: grid },
+      },
+    });
+    const back = parseChartXml(chartToBytes(space));
+    expect(back.plotArea.catAx?.minorGridlines).toBe(true);
+    const major = back.plotArea.valAx?.majorGridlines;
+    expect(major).not.toBe(true);
+    expect(typeof major === 'object' && major?.spPr?.ln?.fill?.kind).toBe('solidFill');
+  });
+});


### PR DESCRIPTION
## Summary

ECMA-376 lets \`<c:majorGridlines>\` / \`<c:minorGridlines>\` carry a full \`<c:spPr>\` so the gridline can be coloured / dashed / weighted. xlsx-kit previously only modelled the boolean on/off case, so callers had to live with Excel's default gridline appearance (which doesn't match corporate-style light-grey \`D9D9D9\` palettes).

\`AxisShared.majorGridlines\` and \`AxisShared.minorGridlines\` now accept \`boolean | Gridlines\` where \`Gridlines\` is \`{ spPr?: ShapeProperties }\`. The plain \`true\` form keeps emitting \`<c:majorGridlines/>\` so existing call sites stay green; the object form unlocks colour parity with openpyxl's \`graphicalProperties\`. Parser is symmetric — empty element parses back to \`true\`, populated element parses to \`{ spPr }\`.

Closes #57.

## Test plan

- [x] \`pnpm vitest run tests/chart/issue-57.test.ts\` (3 tests: boolean back-compat, styled serialise, round-trip)
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (full suite — 2265 passing)
- [x] \`pnpm build && pnpm size\` (all subpaths within budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)