### PR TITLE
docs(readme): note openpyxl-migration defaults that differ

### DIFF
--- a/.changeset/openpyxl-migration-note.md
+++ b/.changeset/openpyxl-migration-note.md
@@ -1,0 +1,5 @@
+---
+'xlsx-kit': patch
+---
+
+Document the small set of openpyxl → xlsx-kit defaults that differ, in particular that `createWorkbook()` returns an empty workbook with no sheets (unlike `openpyxl.Workbook()` which creates a default `'Sheet'`). Direct ports of openpyxl code that include a `wb.remove(wb.active)` call after `Workbook()` were translating that into a no-op `removeSheet(wb, 'Sheet')` — the new README "Migrating from openpyxl" subsection calls this out alongside the `setCell` and `makeBorder` / `makeSide` equivalents. Closes #62.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,26 @@ worksheet payload. Band queries (`minRow > 1`) build a row-offset index once
 per sheet, which does materialise that sheet's inflated bytes; subsequent
 band queries reuse the cached index.
 
+### Migrating from openpyxl
+
+xlsx-kit is shaped after openpyxl, but a few defaults differ. The most
+common surprise for direct ports:
+
+- **`createWorkbook()` returns an empty workbook with no sheets.**
+  `openpyxl.Workbook()` creates a default sheet named `Sheet` that
+  callers usually remove with `wb.remove(wb.active)`. xlsx-kit skips
+  that step — call `addWorksheet(wb, 'Data')` directly. Translating a
+  `remove(active)` call literally produces a no-op (or, worse, a guard
+  that hides a real bug elsewhere).
+- **`setCell(ws, row, col, value)`** is the xlsx-kit equivalent of
+  openpyxl's `ws.cell(row=r, column=c, value=v)`. Coordinates are
+  1-based on both sides.
+- **`makeBorder({ left: makeSide({ style: 'thin' }) })`** is the
+  xlsx-kit equivalent of openpyxl's
+  `Border(left=Side(style='thin'))`. Same with `makeFill`, `makeFont`,
+  etc. — every style primitive has a `make*` constructor under
+  `xlsx-kit/styles`.
+
 ## What's supported
 
 - ✅ Cell values: number, string (sharedStrings), boolean, error, formulas


### PR DESCRIPTION
## Summary

\`createWorkbook()\` returns an **empty** workbook with no sheets, unlike \`openpyxl.Workbook()\` which creates a default \`'Sheet'\` that callers usually drop with \`wb.remove(wb.active)\`. Direct ports of openpyxl code often translate that line into a no-op \`removeSheet(wb, 'Sheet')\` — or worse, a guard that masks a real bug elsewhere.

Add a short "Migrating from openpyxl" subsection at the end of "Quick examples" that:

- calls out the empty-workbook default explicitly,
- maps \`ws.cell(row=r, column=c, value=v)\` → \`setCell(ws, row, col, value)\`,
- maps \`Border(left=Side(...))\` → \`makeBorder({ left: makeSide(...) })\`.

Closes #62.

## Test plan

- [x] Render the README locally — the new subsection appears between the streaming-read example and "What's supported".

🤖 Generated with [Claude Code](https://claude.com/claude-code)