### PR TITLE
audit: harden read/write paths and unify XML escape

### DIFF
--- a/.changeset/chartsheet-tab-color.md
+++ b/.changeset/chartsheet-tab-color.md
@@ -1,0 +1,19 @@
+---
+'xlsx-kit': minor
+---
+
+**Breaking**: `Chartsheet.properties.tabColor` replaces `tabColorRgb`.
+
+Worksheets already expose `SheetProperties.tabColor` as a full `Color` (rgb / indexed / theme / auto / tint). Chartsheets carried a stringly-typed `tabColorRgb` instead, which forced callers to special-case the two sheet kinds and silently dropped every non-RGB colour attribute Excel produces.
+
+The new field is a `Color` object so both sheet kinds share one tab-colour model. Migration:
+
+```ts
+// Before
+cs.properties = { tabColorRgb: 'FF8800' };
+
+// After
+cs.properties = { tabColor: { rgb: 'FF8800' } };
+```
+
+Reads recover the additional `indexed` / `theme` / `auto` / `tint` attributes that the old shape discarded.

--- a/.changeset/ci-lint-hardening.md
+++ b/.changeset/ci-lint-hardening.md
@@ -1,0 +1,11 @@
+---
+'xlsx-kit': patch
+---
+
+chore(ci): tighten the CI gate and surface CLAUDE.md hard rules in the linter.
+
+- The test matrix now runs on macOS and Windows alongside Ubuntu. Path-separator and TextDecoder differences that ubuntu-only CI would silently miss are now exercised on every PR. Each OS installs `libxml2-utils` / `libxml2` so the ECMA-376 conformance gate never silently degrades to "no schema validation ran".
+
+- A dedicated `perf` job runs `pnpm test:perf` with `PERF_GATE=1`, promoting the throughput / heap thresholds in `tests/perf/` from informational to fatal. CI runners are noisier than the M1 baseline the gates target — if a specific Node minor turns flaky, retune the thresholds in `vitest.perf.config.ts` rather than reverting this gate.
+
+- `typescript/no-explicit-any` is `error` in `src/` and `off` in `tests/` (where `as any` is a legitimate way to exercise error paths). The remaining intentional `any` in `src/schema/core.ts` is annotated with `// oxlint-disable-next-line typescript/no-explicit-any` and an explanation comment.

--- a/.changeset/escape-unification.md
+++ b/.changeset/escape-unification.md
@@ -1,0 +1,11 @@
+---
+'xlsx-kit': patch
+---
+
+refactor: route every XML writer through one canonical `escapeXmlAttr` / `escapeXmlText` pair in `src/utils/escape.ts`.
+
+Before, twelve files each carried their own near-identical escape regex — `src/io/save.ts` deliberately skipped `>` while the rest escaped it, and three of them also escaped `\r` / `\n` / `\t` via numeric character references. The discrepancies were quiet correctness bugs (attribute values containing `]]>` rendered differently across writers) and a maintenance hazard.
+
+The unified helpers escape `&`, `<`, `>`, and `"`; whitespace bytes stay literal because our parser (`fast-xml-parser`) does not decode numeric character references and would otherwise break the round-trip.
+
+No user-visible behaviour change beyond consistent attribute escaping across every writer.

--- a/.changeset/perf-hot-paths.md
+++ b/.changeset/perf-hot-paths.md
@@ -1,0 +1,13 @@
+---
+'xlsx-kit': patch
+---
+
+perf: drop quadratic / linear-scan patterns on four read/write hot paths.
+
+- The `loadWorkbook` resolver indexes each sheet's rels file once via the new `indexRelsById` helper instead of running a fresh `Array.find(r => r.id === relId)` per table / comments / drawing / chart / picture cross-reference. Worksheets with many drawings or pivot tables load in O(refs) instead of O(refs × rels).
+
+- `containsCommentMarker` in the VML drawing classifier replaces a byte-by-byte JS loop with a single latin1 `String.indexOf` — multi-megabyte legacy VML drawings load noticeably faster.
+
+- The streaming `iterParse` queue uses a head pointer instead of `Array#shift()`. A single SAX batch with hundreds of events (typical for a wide `<row>`) is now O(N) instead of O(N²); a stale dead-code branch in the prologue gate is gone too.
+
+- `serializeHyperlinks` allocates rIds via a `Set` index instead of nested `Array.some()` calls. Worksheets with hundreds of hyperlinks (dashboards / link-heavy index sheets) finish save in O(N) rather than O(N²).

--- a/.changeset/single-pass-describe.md
+++ b/.changeset/single-pass-describe.md
@@ -1,0 +1,11 @@
+---
+'xlsx-kit': patch
+---
+
+refactor: collapse `describeWorkbook` into a single pass, harden `getRowValues`, and document `normalizePath`'s `..` handling.
+
+`describeWorkbook` used to walk every cell three times — once for `getWorkbookStats`, once for `getWorkbookCellsByKind`, and once again for the per-sheet counts. The new implementation fuses all three into one pass and shares the value-kind classifier with `countCellsByKind` via the newly exported `classifyCellValue` (so the two never drift on edge cases like `Date` vs `duration`).
+
+`getRowValues` no longer derives `maxCol` via `Math.max(...rowMap.keys())`. The spread is limited by V8's argument-count cap (~125 k), which `getRowValues` would silently blow past on a dense row near MAX_COL — the call now uses a linear scan to derive the max.
+
+`normalizePath` picks up an explanatory comment for the `..`-when-`out`-is-empty case, so the next reader doesn't have to second-guess whether path-traversal is possible (it isn't — the archive lookup catches escape attempts naturally).

--- a/.changeset/sink-lifecycle.md
+++ b/.changeset/sink-lifecycle.md
@@ -1,0 +1,15 @@
+---
+'xlsx-kit': minor
+---
+
+fix: release streaming sinks when serialization fails, and bound the streaming write-only buffer against CJK payloads.
+
+When `saveWorkbook` or `createWriteOnlyWorkbook().finalize()` threw partway through serialization, the underlying sink stayed open — `toFile` would leave a half-written `.xlsx` on disk that callers could mistake for a successful save. `BufferedSinkWriter` now exposes an optional `abort(cause?)` hook; the ZIP writer + workbook writers call it from a surrounding `catch` so streaming destinations (`toFile` / `toWritable`) are released and the partial file is best-effort removed. The write-only workbook also exposes its own `abort(cause?)` for callers driving it from a custom pipeline.
+
+The streaming write-only worksheet's pending-byte counter and the XML stream writer's flush threshold now use an accurate UTF-8 length (`utf8ByteLength`) instead of `string.length`. The previous accounting undercounted CJK text by ~3×, letting the in-flight buffer grow well past the configured flush threshold; Japanese / Chinese workloads now flush at the documented ~64 KB ceiling.
+
+API:
+
+- `BufferedSinkWriter.abort(cause?)` is optional. Custom sinks don't need to implement it, but doing so lets `saveWorkbook` clean up streaming destinations on failure.
+- `WriteOnlyWorkbook.abort(cause?)` is the matching escape hatch on the write-only API.
+- `XlsxSink.toBytes` is now required at the type level. It was already required in practice — the writer threw at runtime when it was missing — and built-in sinks (`toBuffer` / `toBlob` / `toArrayBuffer` / `toFile` / `toWritable`) already implement it.

--- a/.changeset/worksheet-correctness.md
+++ b/.changeset/worksheet-correctness.md
@@ -1,0 +1,11 @@
+---
+'xlsx-kit': minor
+---
+
+fix: tighten three worksheet / cell mutation paths that previously produced silently-bad workbooks.
+
+- `copyRange` / `moveRange` no longer carry `hyperlinkId` / `commentId` across worksheets. Those fields are indexes into the source sheet's `hyperlinks` / `legacyComments` arrays and would point at unrelated records (or out of bounds) on the destination. Same-sheet copy / move still preserves them.
+
+- `setSheetState` refuses to hide the last visible sheet. Excel rejects workbooks with every sheet hidden ("Excel cannot use the object linking and embedding features…"); raising at mutation time keeps the workbook recoverable instead of producing a save Excel will reject.
+
+- `makeTextRun` throws `OpenXmlSchemaError` instead of `TypeError` so every public error path uses the documented `OpenXmlError` subclass hierarchy.

--- a/.changeset/zip64-bomb-defense.md
+++ b/.changeset/zip64-bomb-defense.md
@@ -1,0 +1,9 @@
+---
+'xlsx-kit': patch
+---
+
+fix: harden the ZIP64 read path against decompression bombs.
+
+Previously, archives whose End-of-Central-Directory carried ZIP64 sentinel values fell back to `fflate.unzipSync`, which inflates every entry up front. A crafted ZIP64-shaped xlsx could exhaust memory before the per-entry / archive-total caps ran. The random-access reader now parses ZIP64 EOCD + the Zip64 Extended Information extra field directly, so the existing decompression-bomb guards apply to ZIP64 archives the same way they apply to ZIP32.
+
+`loadWorkbook(decompressionLimits)` defaults are unchanged; only the underlying enforcement path is stricter.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,17 @@ jobs:
       # (docs/plan/06-streaming.md §3.4 acceptance).
       - run: pnpm size
 
-  # Multi-version test matrix. Active LTS lines + Current. Node 18 / 20 are
-  # past EOL and intentionally dropped.
+  # Multi-version, multi-OS test matrix. Active LTS lines + Current; Node 18 /
+  # 20 are past EOL and intentionally dropped. macOS / Windows runs flush out
+  # path-separator and TextDecoder / line-ending assumptions that ubuntu-only
+  # CI would silently miss.
   test:
     needs: static
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: ['22', '24', '26']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -57,8 +60,36 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       # ECMA-376 conformance tests shell out to xmllint (libxml2-utils).
-      # ubuntu-latest usually ships it, but install explicitly so the gate
-      # never silently degrades to "no schema validation ran".
-      - run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+      # Install explicitly on each OS so the gate never silently degrades to
+      # "no schema validation ran" — macOS / Windows runners don't ship it.
+      - if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+      - if: runner.os == 'macOS'
+        run: brew install libxml2
+      - if: runner.os == 'Windows'
+        run: choco install xsltproc --no-progress -y
+        shell: pwsh
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
+
+  # Performance regression gate. Runs the dedicated perf-test config with
+  # PERF_GATE=1 so the throughput thresholds in tests/perf/ fail the run on
+  # regressions instead of skipping silently.
+  perf:
+    needs: static
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # PERF_GATE=1 promotes the throughput / heap regressions in tests/perf/
+      # from informational to fatal. CI runners are noisy compared to the M1
+      # baseline the gates are calibrated against; revisit the thresholds in
+      # the perf config if this turns flaky on a specific Node minor.
+      - run: PERF_GATE=1 pnpm test:perf

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -98,7 +98,7 @@
     "require-await": "off",
     "require-yield": "off",
     "symbol-description": "off",
-    "typescript/no-explicit-any": "off",
+    "typescript/no-explicit-any": "error",
     "typescript/no-empty-object-type": "off",
     "typescript/no-namespace": "off",
     "typescript/no-unsafe-function-type": "off",
@@ -257,5 +257,13 @@
     "unicorn/text-encoding-identifier-case": "off",
     "unicorn/throw-new-error": "off"
   },
-  "ignorePatterns": ["dist", "reference", "node_modules", "coverage"]
+  "ignorePatterns": ["dist", "reference", "node_modules", "coverage"],
+  "overrides": [
+    {
+      "files": ["tests/**/*.ts", "tests/**/*.tsx", "site/**/*.ts", "site/**/*.tsx"],
+      "rules": {
+        "typescript/no-explicit-any": "off"
+      }
+    }
+  ]
 }

--- a/src/cell/rich-text.ts
+++ b/src/cell/rich-text.ts
@@ -8,6 +8,7 @@
 // renaming.
 
 import type { Color } from '../styles/colors';
+import { OpenXmlSchemaError } from '../utils/exceptions';
 
 /** Underline styles per openpyxl's cell-level NestedNoneSet. */
 export type InlineUnderline = 'single' | 'double' | 'singleAccounting' | 'doubleAccounting';
@@ -42,7 +43,7 @@ export type RichText = ReadonlyArray<TextRun>;
 
 export function makeTextRun(text: string, font?: InlineFont): TextRun {
   if (typeof text !== 'string') {
-    throw new TypeError('makeTextRun: text must be a string');
+    throw new OpenXmlSchemaError('makeTextRun: text must be a string');
   }
   return Object.freeze(font !== undefined ? { text, font } : { text });
 }

--- a/src/chart/chart-xml.ts
+++ b/src/chart/chart-xml.ts
@@ -13,6 +13,7 @@ import {
 } from '../drawing/dml/dml-xml';
 import type { ShapeProperties } from '../drawing/dml/shape-properties';
 import type { TextBody } from '../drawing/dml/text';
+import { escapeXmlText } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import { CHART_NS, REL_NS, SHEET_DRAWING_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
@@ -271,7 +272,7 @@ const A_T_TAG = '{http://schemas.openxmlformats.org/drawingml/2006/main}t';
 
 const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
-const escapeText = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const escapeText = escapeXmlText;
 
 const valAttr = (n: XmlNode | undefined): string | undefined => n?.attrs['val'];
 const intVal = (n: XmlNode | undefined): number | undefined => {

--- a/src/chart/cx/chartex-xml.ts
+++ b/src/chart/cx/chartex-xml.ts
@@ -8,6 +8,7 @@ import {
 } from '../../drawing/dml/dml-xml';
 import type { ShapeProperties } from '../../drawing/dml/shape-properties';
 import type { TextBody } from '../../drawing/dml/text';
+import { escapeXmlAttr, escapeXmlText } from '../../utils/escape';
 import { OpenXmlSchemaError } from '../../utils/exceptions';
 import { CX_NS, REL_NS } from '../../xml/namespaces';
 import { parseXml } from '../../xml/parser';
@@ -86,8 +87,8 @@ const parseTxPrSlot = (parent: XmlNode): TextBody | undefined => {
 
 const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
-const escapeText = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-const escapeAttr = (s: string): string => escapeText(s).replace(/"/g, '&quot;');
+const escapeText = escapeXmlText;
+const escapeAttr = escapeXmlAttr;
 
 const valAttr = (n: XmlNode | undefined): string | undefined => n?.attrs['val'];
 const intAttr = (n: XmlNode, name: string): number | undefined => {

--- a/src/chart/user-shapes-xml.ts
+++ b/src/chart/user-shapes-xml.ts
@@ -7,6 +7,7 @@ import {
   serializeTextBody,
 } from '../drawing/dml/dml-xml';
 import type { PositiveSize2D } from '../drawing/dml/shape-properties';
+import { escapeXmlAttr } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import { CHART_DRAWING_NS, DRAWING_NS, REL_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
@@ -45,9 +46,7 @@ const A_BLIP = A('blip');
 
 const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
-const escapeText = (s: string): string =>
-  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-const escapeAttr = (s: string): string => escapeText(s).replace(/"/g, '&quot;');
+const escapeAttr = escapeXmlAttr;
 
 const parseFloatText = (text: string | undefined): number | undefined => {
   if (text === undefined) return undefined;

--- a/src/chartsheet/chartsheet-xml.ts
+++ b/src/chartsheet/chartsheet-xml.ts
@@ -1,5 +1,7 @@
 // `xl/chartsheets/sheetN.xml` reader / writer.
 
+import type { Color } from '../styles/colors';
+import { escapeXmlAttr } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import { REL_NS, SHEET_MAIN_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
@@ -47,8 +49,7 @@ const CUSTOM_SHEET_VIEW_TAG = `{${SHEET_MAIN_NS}}customSheetView`;
 
 const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
-const escapeAttr = (s: string): string =>
-  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+const escapeAttr = escapeXmlAttr;
 
 const parseBool = (v: string | undefined): boolean | undefined => {
   if (v === undefined) return undefined;
@@ -70,8 +71,21 @@ const parseSheetPr = (el: XmlNode): ChartsheetProperties | undefined => {
   if (el.attrs['codeName'] !== undefined) out.codeName = el.attrs['codeName'];
   const tab = findChild(el, TAB_COLOR_TAG);
   if (tab) {
-    const rgb = tab.attrs['rgb'];
-    if (rgb) out.tabColorRgb = rgb.toUpperCase();
+    const rgbRaw = tab.attrs['rgb'];
+    const indexed = parseInt10(tab.attrs['indexed']);
+    const theme = parseInt10(tab.attrs['theme']);
+    const auto = parseBool(tab.attrs['auto']);
+    const tintRaw = tab.attrs['tint'];
+    const tintNum = tintRaw !== undefined ? Number.parseFloat(tintRaw) : undefined;
+    const tint = tintNum !== undefined && Number.isFinite(tintNum) ? tintNum : undefined;
+    const color: Color = {
+      ...(rgbRaw !== undefined ? { rgb: rgbRaw.toUpperCase() } : {}),
+      ...(indexed !== undefined ? { indexed } : {}),
+      ...(theme !== undefined ? { theme } : {}),
+      ...(auto !== undefined ? { auto } : {}),
+      ...(tint !== undefined ? { tint } : {}),
+    };
+    if (Object.keys(color).length > 0) out.tabColor = color;
   }
   return Object.keys(out).length > 0 ? out : undefined;
 };
@@ -272,7 +286,17 @@ const serializeSheetPr = (p: ChartsheetProperties): string => {
   const attrs: string[] = [];
   if (p.published !== undefined) attrs.push(`published="${p.published ? '1' : '0'}"`);
   if (p.codeName !== undefined) attrs.push(`codeName="${escapeAttr(p.codeName)}"`);
-  const tab = p.tabColorRgb ? `<tabColor rgb="${p.tabColorRgb}"/>` : '';
+  let tab = '';
+  if (p.tabColor) {
+    const c = p.tabColor;
+    let tcAttrs = '';
+    if (c.rgb !== undefined) tcAttrs += ` rgb="${escapeAttr(c.rgb)}"`;
+    if (c.indexed !== undefined) tcAttrs += ` indexed="${c.indexed}"`;
+    if (c.theme !== undefined) tcAttrs += ` theme="${c.theme}"`;
+    if (c.auto !== undefined) tcAttrs += ` auto="${c.auto ? '1' : '0'}"`;
+    if (c.tint !== undefined) tcAttrs += ` tint="${c.tint}"`;
+    tab = `<tabColor${tcAttrs}/>`;
+  }
   return tab === ''
     ? `<sheetPr${attrs.length > 0 ? ` ${attrs.join(' ')}` : ''}/>`
     : `<sheetPr${attrs.length > 0 ? ` ${attrs.join(' ')}` : ''}>${tab}</sheetPr>`;

--- a/src/chartsheet/chartsheet.ts
+++ b/src/chartsheet/chartsheet.ts
@@ -7,6 +7,7 @@
 // with the chart.
 
 import type { Drawing } from '../drawing/drawing';
+import type { Color } from '../styles/colors';
 import type { HeaderFooter, PageMargins, PageSetup } from '../worksheet/page-setup';
 import type { WebPublishItem } from '../worksheet/web-publish';
 
@@ -22,8 +23,12 @@ export interface ChartsheetView {
 export interface ChartsheetProperties {
   published?: boolean;
   codeName?: string;
-  /** Tab color as RRGGBB (no alpha). */
-  tabColorRgb?: string;
+  /**
+   * Tab strip colour. Mirrors `SheetProperties.tabColor` on worksheets so the
+   * two sheet kinds expose the same colour model (rgb / indexed / theme /
+   * auto / tint) instead of forcing callers to special-case chartsheets.
+   */
+  tabColor?: Color;
 }
 
 /** Subset of `<sheetProtection>` fields we round-trip on chartsheets. */

--- a/src/drawing/dml/dml-xml.ts
+++ b/src/drawing/dml/dml-xml.ts
@@ -1,5 +1,6 @@
 // DrawingML primitive parse / serialize.
 
+import { escapeXmlAttr, escapeXmlText } from '../../utils/escape';
 import { OpenXmlSchemaError } from '../../utils/exceptions';
 import { DRAWING_NS, REL_NS } from '../../xml/namespaces';
 import { findChild, findChildren, type XmlNode } from '../../xml/tree';
@@ -66,8 +67,8 @@ import type {
 
 const A = (local: string): string => `{${DRAWING_NS}}${local}`;
 
-const escapeText = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-const escapeAttr = (s: string): string => escapeText(s).replace(/"/g, '&quot;');
+const escapeText = escapeXmlText;
+const escapeAttr = escapeXmlAttr;
 
 const valAttr = (n: XmlNode | undefined): string | undefined => n?.attrs['val'];
 const intAttr = (n: XmlNode, name: string): number | undefined => {

--- a/src/drawing/drawing-xml.ts
+++ b/src/drawing/drawing-xml.ts
@@ -2,6 +2,7 @@
 // envelope round-trip for the chart variant; picture / shape / connector /
 // group remain unsupported placeholders for later iterations.
 
+import { escapeXmlAttr } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import { DRAWING_NS, REL_NS, SHEET_DRAWING_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
@@ -37,7 +38,7 @@ const PIC_SP_PR_TAG = `{${SHEET_DRAWING_NS}}spPr`;
 const A_BLIP_TAG = `{${DRAWING_NS}}blip`;
 
 const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
-const escapeAttr = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+const escapeAttr = escapeXmlAttr;
 
 const parseIntChild = (parent: XmlNode, tag: string): number | undefined => {
   const child = findChild(parent, tag);

--- a/src/io/browser.ts
+++ b/src/io/browser.ts
@@ -196,6 +196,11 @@ export function toBlob(
         async finish(): Promise<Uint8Array> {
           return finalise();
         },
+        abort(): void {
+          if (finalised !== undefined) return;
+          finalised = new Uint8Array(0);
+          chunks.length = 0;
+        },
       };
     },
     result(): Blob {
@@ -229,6 +234,11 @@ export function toArrayBuffer(): XlsxSink & { toBytes(): BufferedSinkWriter; res
         },
         async finish(): Promise<Uint8Array> {
           return finalise();
+        },
+        abort(): void {
+          if (finalised !== undefined) return;
+          finalised = new Uint8Array(0);
+          chunks.length = 0;
         },
       };
     },

--- a/src/io/load.ts
+++ b/src/io/load.ts
@@ -21,7 +21,7 @@ import { corePropsFromBytes } from '../packaging/core';
 import { customPropsFromBytes } from '../packaging/custom';
 import { extendedPropsFromBytes } from '../packaging/extended';
 import { manifestFromBytes } from '../packaging/manifest';
-import { findById, relsFromBytes } from '../packaging/relationships';
+import { findById, indexRelsById, relsFromBytes } from '../packaging/relationships';
 import { parseStylesheetXml } from '../styles/stylesheet-reader';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import type { DefinedName } from '../workbook/defined-names';
@@ -349,27 +349,33 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
     }
     const sheetRelsPath = relsPathFor(sheetPath);
     const sheetRels = archive.has(sheetRelsPath) ? relsFromBytes(archive.read(sheetRelsPath)) : undefined;
-    const loadTable = sheetRels
+    // Build an id → rel index once; the loadTable / loadComments / loadDrawing
+    // callbacks are invoked once per cross-reference in the worksheet body and
+    // a linear find() inside each would be O(rels × refs). Sheets with many
+    // hyperlinks / tables / drawings (e.g. dashboard workbooks) make that
+    // accumulation visible.
+    const sheetRelsById = sheetRels ? indexRelsById(sheetRels) : undefined;
+    const loadTable = sheetRelsById
       ? (relId: string) => {
-          const tRel = sheetRels.rels.find((r) => r.id === relId);
+          const tRel = sheetRelsById.get(relId);
           if (!tRel) return undefined;
           const tablePath = resolveRelTarget(sheetPath, tRel.target);
           if (!archive.has(tablePath)) return undefined;
           return parseTableXml(archive.read(tablePath));
         }
       : undefined;
-    const loadComments = sheetRels
+    const loadComments = sheetRelsById
       ? (relId: string) => {
-          const cRel = sheetRels.rels.find((r) => r.id === relId);
+          const cRel = sheetRelsById.get(relId);
           if (!cRel) return undefined;
           const cPath = resolveRelTarget(sheetPath, cRel.target);
           if (!archive.has(cPath)) return undefined;
           return parseCommentsXml(archive.read(cPath));
         }
       : undefined;
-    const loadDrawing = sheetRels
+    const loadDrawing = sheetRelsById
       ? (relId: string) => {
-          const dRel = sheetRels.rels.find((r) => r.id === relId);
+          const dRel = sheetRelsById.get(relId);
           if (!dRel) return undefined;
           const dPath = resolveRelTarget(sheetPath, dRel.target);
           if (!archive.has(dPath)) return undefined;
@@ -378,11 +384,12 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
           const dRelsPath = relsPathFor(dPath);
           if (archive.has(dRelsPath)) {
             const dRels = relsFromBytes(archive.read(dRelsPath));
+            const dRelsById = indexRelsById(dRels);
             for (const item of drawing.items) {
               if (item.content.kind === 'chart') {
                 const chartRId = item.content.chart.rId;
                 if (!chartRId) continue;
-                const chartRel = dRels.rels.find((r) => r.id === chartRId);
+                const chartRel = dRelsById.get(chartRId);
                 if (!chartRel) continue;
                 const chartPath = resolveRelTarget(dPath, chartRel.target);
                 if (archive.has(chartPath)) {
@@ -398,7 +405,7 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
                       const chartRelsPath = relsPathFor(chartPath);
                       if (archive.has(chartRelsPath)) {
                         const chartRelsObj = relsFromBytes(archive.read(chartRelsPath));
-                        const usRel = chartRelsObj.rels.find((r) => r.id === userShapesRId);
+                        const usRel = indexRelsById(chartRelsObj).get(userShapesRId);
                         if (usRel) {
                           const usPath = resolveRelTarget(chartPath, usRel.target);
                           if (archive.has(usPath)) {
@@ -419,7 +426,7 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
               } else if (item.content.kind === 'picture') {
                 const picRId = item.content.picture.rId;
                 if (!picRId) continue;
-                const picRel = dRels.rels.find((r) => r.id === picRId);
+                const picRel = dRelsById.get(picRId);
                 if (!picRel) continue;
                 const imgPath = resolveRelTarget(dPath, picRel.target);
                 if (archive.has(imgPath)) {
@@ -1072,28 +1079,19 @@ const PASSTHROUGH_PREFIXES: ReadonlyArray<string> = [
  *  - Without marker → control / OLE / shape VML; capture as
  * passthrough so form controls survive load → save → load.
  */
-const COMMENT_VML_MARKER: ReadonlyArray<number> = (() => {
-  const marker = new TextEncoder().encode('ObjectType="Note"');
-  return Array.from(marker);
-})();
+const COMMENT_VML_MARKER = 'ObjectType="Note"';
+// Latin-1 is a 1-to-1 byte-to-character mapping for the 0–255 range, so a
+// String.indexOf scan on the decoded view returns the same answer as a byte
+// search but takes advantage of V8's native StringPrototypeIndexOf — orders
+// of magnitude faster than the JS loop the previous implementation used on
+// multi-megabyte VML drawings.
+const LATIN1_DECODER = new TextDecoder('latin1');
 
 const isVmlDrawing = (path: string): boolean =>
   path.startsWith('xl/drawings/') && path.endsWith('.vml');
 
-const containsCommentMarker = (bytes: Uint8Array): boolean => {
-  const len = COMMENT_VML_MARKER.length;
-  for (let i = 0; i + len <= bytes.length; i++) {
-    let match = true;
-    for (let j = 0; j < len; j++) {
-      if (bytes[i + j] !== COMMENT_VML_MARKER[j]) {
-        match = false;
-        break;
-      }
-    }
-    if (match) return true;
-  }
-  return false;
-};
+const containsCommentMarker = (bytes: Uint8Array): boolean =>
+  LATIN1_DECODER.decode(bytes).includes(COMMENT_VML_MARKER);
 
 /**
  * Top-level xl/*.xml files that aren't modeled but Excel relies on (or

--- a/src/io/load.ts
+++ b/src/io/load.ts
@@ -90,6 +90,12 @@ function normalizePath(path: string): string {
   for (const seg of segments) {
     if (seg === '' || seg === '.') continue;
     if (seg === '..') {
+      // Pop the last accumulated segment when one exists; when `out` is
+      // empty (a relative target with more `..` than ancestors) the pop is
+      // a no-op so the climb is silently absorbed at the package root. The
+      // archive.has() check on the resolved path catches any escape attempt
+      // because the entry simply won't exist outside the package — there's
+      // no filesystem traversal to worry about, only a missing-entry error.
       out.pop();
       continue;
     }

--- a/src/io/node-fs.ts
+++ b/src/io/node-fs.ts
@@ -8,7 +8,7 @@
 // that subpath lands).
 
 import { createReadStream, createWriteStream, readFileSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { readFile, unlink } from 'node:fs/promises';
 import { once } from 'node:events';
 import { Readable, Writable } from 'node:stream';
 import { OpenXmlIoError } from '../utils/exceptions';
@@ -98,6 +98,7 @@ export function toFile(path: string): XlsxSink & { toBytes(): BufferedSinkWriter
     throw new OpenXmlIoError('toFile expects a non-empty path string');
   }
   let stream: ReturnType<typeof createWriteStream> | undefined;
+  let streamCreated = false;
   let finalised: Promise<Uint8Array> | undefined;
   let pendingError: Error | undefined;
   // Backpressure queue: every chunk's actual `writable.write` call is staged
@@ -109,11 +110,25 @@ export function toFile(path: string): XlsxSink & { toBytes(): BufferedSinkWriter
   const ensureStream = (): NonNullable<typeof stream> => {
     if (!stream) {
       stream = createWriteStream(path);
+      streamCreated = true;
       stream.on('error', (err) => {
         pendingError = err instanceof Error ? err : new Error(String(err));
       });
     }
     return stream;
+  };
+
+  // Best-effort: remove a half-written file when finish() fails so callers
+  // don't mistake a corrupt artefact for a successful save. Swallows unlink
+  // errors because we're already in a failure path and the original cause
+  // is what the caller needs to see.
+  const cleanupOnFailure = async (): Promise<void> => {
+    if (!streamCreated) return;
+    try {
+      await unlink(path);
+    } catch {
+      // ignore — file may be gone, path may be on a read-only fs, etc.
+    }
   };
 
   return {
@@ -142,14 +157,34 @@ export function toFile(path: string): XlsxSink & { toBytes(): BufferedSinkWriter
           if (finalised) return finalised;
           finalised = (async () => {
             const s = ensureStream();
-            await writeQueue;
-            await new Promise<void>((resolve, reject) => {
-              s.end((err?: Error | null) => (err ? reject(err) : resolve()));
-            });
-            if (pendingError) throw new OpenXmlIoError(`toFile sink: write error on "${path}"`, { cause: pendingError });
+            try {
+              await writeQueue;
+              await new Promise<void>((resolve, reject) => {
+                s.end((err?: Error | null) => (err ? reject(err) : resolve()));
+              });
+              if (pendingError) {
+                throw new OpenXmlIoError(`toFile sink: write error on "${path}"`, { cause: pendingError });
+              }
+            } catch (err) {
+              await cleanupOnFailure();
+              throw err;
+            }
             return EMPTY_BYTES;
           })();
           return finalised;
+        },
+        abort(): void {
+          // Idempotent: subsequent finish() / abort() calls become no-ops.
+          if (finalised) return;
+          finalised = Promise.resolve(EMPTY_BYTES);
+          if (stream) {
+            // destroy() releases the fd synchronously without flushing the
+            // pending buffer — exactly what we want for an aborted save.
+            stream.destroy();
+          }
+          // Fire-and-forget unlink — abort() is sync (void), and the caller
+          // is already on a failure path so any unlink error is noise.
+          void cleanupOnFailure();
         },
       };
     },
@@ -243,6 +278,13 @@ export function toWritable(writable: Writable): XlsxSink & { toBytes(): Buffered
             return EMPTY_BYTES;
           })();
           return finalised;
+        },
+        abort(cause?: unknown): void {
+          if (finalised) return;
+          finalised = Promise.resolve(EMPTY_BYTES);
+          // Pass the cause to destroy() so downstream `error` listeners can
+          // distinguish a deliberate abort from spontaneous fs/network errors.
+          writable.destroy(cause instanceof Error ? cause : undefined);
         },
       };
     },

--- a/src/io/node.ts
+++ b/src/io/node.ts
@@ -75,6 +75,11 @@ export function toBuffer(): XlsxSink & { toBytes(): BufferedSinkWriter; result()
         async finish(): Promise<Uint8Array> {
           return finalise();
         },
+        abort(): void {
+          if (finalised !== undefined) return;
+          finalised = new Uint8Array(0);
+          chunks.length = 0;
+        },
       };
     },
     result(): Buffer {

--- a/src/io/save.ts
+++ b/src/io/save.ts
@@ -14,6 +14,7 @@
 // docProps / theme / VBA / drawings / charts are reserved for later iterations
 // — load tolerates their absence.
 
+import { escapeXmlAttr, escapeXmlText } from '../utils/escape';
 import { chartToBytes } from '../chart/chart-xml';
 import { chartExToBytes } from '../chart/cx/chartex-xml';
 import { userShapesToBytes } from '../chart/user-shapes-xml';
@@ -131,6 +132,11 @@ const toUint8ArraySink = (): XlsxSink & { result(): Uint8Array } => {
         async finish(): Promise<Uint8Array> {
           return finalise();
         },
+        abort(): void {
+          if (finalised !== undefined) return;
+          finalised = new Uint8Array(0);
+          chunks.length = 0;
+        },
       };
     },
     result(): Uint8Array {
@@ -175,7 +181,18 @@ const validateSheetTitles = (wb: Workbook): void => {
 export async function saveWorkbook(wb: Workbook, sink: XlsxSink, _opts: SaveOptions = {}): Promise<void> {
   validateSheetTitles(wb);
   const writer = createZipWriter(sink);
+  try {
+    await saveWorkbookImpl(wb, writer);
+  } catch (err) {
+    // Release the sink so streaming destinations (`toFile` / `toWritable`)
+    // don't leave a half-written file looking valid. abort() is idempotent so
+    // a successful finalize() above is a no-op here.
+    writer.abort(err);
+    throw err;
+  }
+}
 
+async function saveWorkbookImpl(wb: Workbook, writer: ReturnType<typeof createZipWriter>): Promise<void> {
   // ---- 1. assemble the per-sheet rels + serialise each worksheet ----------
   const sst = makeSharedStrings();
   interface SheetEmit {
@@ -1030,9 +1047,12 @@ function serializeWorkbookProtection(
   return `<workbookProtection${attrs}/>`;
 }
 
-const escapeText = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-const escapeAttr = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+// Local aliases keep the dense call sites below readable. Canonical
+// implementations live in utils/escape.ts so all three writers (this file,
+// xml/serializer, xml/stream-writer) agree on how `>` / whitespace are
+// handled.
+const escapeText = escapeXmlText;
+const escapeAttr = escapeXmlAttr;
 
 /**
  * Serialise an XmlNode child of `<workbook>` for inline injection back into the

--- a/src/io/sink.ts
+++ b/src/io/sink.ts
@@ -16,6 +16,19 @@ export interface BufferedSinkWriter {
    * the sink's own `result()` instead.
    */
   finish(): Promise<Uint8Array>;
+  /**
+   * Abandon the writer. Called by the ZIP writer (and `saveWorkbook` /
+   * `loadWorkbookStream` writers) when the surrounding pipeline throws before
+   * `finish()` runs. Implementations must release any underlying resource:
+   * `toFile` destroys the Node `WriteStream` and best-effort removes the
+   * half-written file; `toWritable` destroys the wrapped Writable; in-memory
+   * sinks simply drop their buffered chunks.
+   *
+   * Idempotent. Must not throw — the surrounding catch already has the cause
+   * the caller cares about; obscuring it with a cleanup error helps nobody.
+   * Optional for backwards compatibility, but writers should provide it.
+   */
+  abort?(cause?: unknown): void | Promise<void>;
 }
 
 export interface XlsxSink {
@@ -28,12 +41,21 @@ export interface XlsxSink {
    * sinks). The ZIP writer never holds the full archive itself, so the choice
    * of sink decides whether peak memory is "compressed archive size" or
    * "single chunk + deflate scratch".
+   *
+   * Required: `createZipWriter` calls this on every sink. The method stayed
+   * `?:` historically while a `toStream()` alternative was being prototyped,
+   * but the streaming-WritableStream variant never landed and leaving it
+   * optional only masked the runtime "sink does not expose toBytes()" error
+   * behind a missing-property exception.
    */
-  toBytes?(): BufferedSinkWriter;
+  toBytes(): BufferedSinkWriter;
 
   /**
    * Streaming mode: returns a WritableStream into which the writer pipes
-   * chunks. Backpressure is honoured by the underlying sink.
+   * chunks. Backpressure is honoured by the underlying sink. Currently
+   * unused by the ZIP writer (see {@link toBytes}); kept optional so that
+   * future writer paths can opt into a `WritableStream`-shaped backend
+   * without breaking existing sink implementations.
    */
   toStream?(): WritableStream<Uint8Array>;
 }

--- a/src/packaging/relationships.ts
+++ b/src/packaging/relationships.ts
@@ -95,6 +95,17 @@ export function findById(rels: Relationships, id: string): Relationship | undefi
   return undefined;
 }
 
+/**
+ * Build an id → relationship index for callers that look up the same .rels
+ * file many times in a hot loop. Cheaper than repeated {@link findById} once
+ * the rels count crosses a handful of entries.
+ */
+export function indexRelsById(rels: Relationships): Map<string, Relationship> {
+  const out = new Map<string, Relationship>();
+  for (const r of rels.rels) out.set(r.id, r);
+  return out;
+}
+
 export function findByType(rels: Relationships, type: string): Relationship | undefined {
   for (const r of rels.rels) if (r.type === type) return r;
   return undefined;

--- a/src/schema/core.ts
+++ b/src/schema/core.ts
@@ -65,8 +65,10 @@ export type ElementDef =
       key: string;
       name?: string;
       xmlNs?: string;
-      // biome-ignore lint/suspicious/noExplicitAny: Schema is contravariant in
-      // T at the element boundary; named types come back via T anyway
+      // Schema is contravariant in T at the element boundary; named types
+      // come back via T anyway. The `any` is intentional — `unknown` would
+      // force a cast in every concrete schema definition with no extra safety.
+      // oxlint-disable-next-line typescript/no-explicit-any
       schema: () => Schema<any>;
       optional?: boolean;
     }
@@ -76,8 +78,8 @@ export type ElementDef =
       /** Local name of the repeated child element. */
       itemName: string;
       itemNs?: string;
-      // biome-ignore lint/suspicious/noExplicitAny: see ElementDef.kind ===
-      // 'object'
+      // See ElementDef.kind === 'object' for why `any` survives here.
+      // oxlint-disable-next-line typescript/no-explicit-any
       itemSchema: () => Schema<any>;
       /** Optional wrapper element holding the items. */
       container?: { name: string; xmlNs?: string; count?: boolean };

--- a/src/streaming/write-only.ts
+++ b/src/streaming/write-only.ts
@@ -30,7 +30,9 @@ import type { Border } from '../styles/borders';
 import type { Fill } from '../styles/fills';
 import type { Font } from '../styles/fonts';
 import type { Protection } from '../styles/protection';
+import { escapeXmlAttr } from '../utils/escape';
 import { OpenXmlIoError } from '../utils/exceptions';
+import { utf8ByteLength } from '../utils/utf8';
 import { makeSharedStrings, sharedStringsToBytes } from '../workbook/shared-strings';
 import { validateSheetTitle } from '../workbook/workbook';
 import { serializeCell } from '../worksheet/writer';
@@ -51,8 +53,7 @@ import {
 } from '../xml/namespaces';
 import { createZipWriter } from '../zip/writer';
 
-const escapeAttr = (s: string): string =>
-  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+const escapeAttr = escapeXmlAttr;
 
 export interface WriteOnlyOptions {
   /** Reserved — currently ignored (the buffered backend doesn't honour it). */
@@ -82,6 +83,16 @@ export interface WriteOnlyWorkbook {
   addWorksheet(title: string): Promise<WriteOnlyWorksheet>;
   /** Finalise the archive: emits styles / sharedStrings / workbook / manifest / rels. */
   finalize(): Promise<void>;
+  /**
+   * Release the sink without finalising the archive. Call this from a
+   * surrounding catch block when the producer pipeline throws before
+   * `finalize()` — without it, streaming destinations (`toFile` /
+   * `toWritable`) keep the file descriptor / Writable open and the partial
+   * xlsx looks valid on disk.
+   *
+   * Idempotent. Subsequent `addWorksheet` / `finalize` calls throw.
+   */
+  abort(cause?: unknown): void;
 }
 
 const validateTitle = (title: string, taken: Set<string>): void => {
@@ -171,7 +182,11 @@ const makeWriteOnlyWorksheet = (state: WorkbookState, title: string, sheetId: nu
 
   const writeText = (text: string): void => {
     pendingText += text;
-    pendingBytes += text.length; // chars approximate bytes; UTF-8 may be larger.
+    // UTF-8 byte length, computed without a full encode: scan once and add the
+    // exact codepoint cost. `text.length` would undercount CJK by ~3× and let
+    // the buffer balloon past FLUSH_THRESHOLD_BYTES on Japanese / Chinese
+    // workloads.
+    pendingBytes += utf8ByteLength(text);
     if (pendingBytes >= FLUSH_THRESHOLD_BYTES) {
       stream.write(encoder.encode(pendingText));
       pendingText = '';
@@ -302,77 +317,93 @@ const makeWriteOnlyWorkbook = (sink: XlsxSink): WriteOnlyWorkbook => {
     }
     state.finalised = true;
     const writer = state.writer;
-
-    // 1. Worksheets — already streamed through writer.addStreamingEntry
-    // during each WriteOnlyWorksheet's appendRow / close cycle.
-
-    // 2. Stylesheet.
-    await writer.addEntry(ARC_STYLE, stylesheetToBytes(state.styles));
-
-    // 3. SharedStrings (only when non-empty).
-    if (state.sst.entries.length > 0) {
-      await writer.addEntry(ARC_SHARED_STRINGS, sharedStringsToBytes(state.sst));
+    try {
+      await finalizeImpl(state, writer);
+    } catch (err) {
+      // Release the sink so the half-emitted archive doesn't linger as a
+      // valid-looking file on disk. abort() is idempotent.
+      writer.abort(err);
+      throw err;
     }
-
-    // 4. workbook.xml.
-    const workbookXml = serializeWorkbookXml(state.sheets);
-    await writer.addEntry(ARC_WORKBOOK, new TextEncoder().encode(workbookXml));
-
-    // 5. workbook.xml.rels.
-    const wbRels = makeRelationships();
-    state.sheets.forEach((s, i) => {
-      wbRels.rels.push({
-        id: `rId${i + 1}`,
-        type: `${REL_NS}/worksheet`,
-        target: `worksheets/sheet${s.sheetId}.xml`,
-      });
-    });
-    if (state.sst.entries.length > 0) {
-      wbRels.rels.push({
-        id: `rId${wbRels.rels.length + 1}`,
-        type: `${REL_NS}/sharedStrings`,
-        target: 'sharedStrings.xml',
-      });
-    }
-    wbRels.rels.push({
-      id: `rId${wbRels.rels.length + 1}`,
-      type: `${REL_NS}/styles`,
-      target: 'styles.xml',
-    });
-    await writer.addEntry(ARC_WORKBOOK_RELS, relsToBytes(wbRels));
-
-    // 6. root rels.
-    const rootRels = makeRelationships();
-    rootRels.rels.push({
-      id: 'rId1',
-      type: `${REL_NS}/officeDocument`,
-      target: 'xl/workbook.xml',
-    });
-    await writer.addEntry(ARC_ROOT_RELS, relsToBytes(rootRels));
-    void PKG_REL_NS; // imported for future docProps support
-
-    // 7. [Content_Types].xml.
-    const manifest = makeManifest();
-    // Excel rejects packages whose [Content_Types].xml is missing the Default
-    // entries for `rels` / `xml` — without them the package relationships file
-    // can't be classified and Excel refuses to open.
-    addDefault(manifest, 'rels', 'application/vnd.openxmlformats-package.relationships+xml');
-    addDefault(manifest, 'xml', 'application/xml');
-    addOverride(manifest, `/${ARC_WORKBOOK}`, XLSX_TYPE);
-    for (const s of state.sheets) {
-      addOverride(manifest, `/xl/worksheets/sheet${s.sheetId}.xml`, WORKSHEET_TYPE);
-    }
-    addOverride(manifest, `/${ARC_STYLE}`, STYLES_TYPE);
-    if (state.sst.entries.length > 0) {
-      addOverride(manifest, `/${ARC_SHARED_STRINGS}`, SHARED_STRINGS_TYPE);
-    }
-    await writer.addEntry(ARC_CONTENT_TYPES, manifestToBytes(manifest));
-
-    await writer.finalize();
   };
 
-  return { addWorksheet, finalize };
+  const abort = (cause?: unknown): void => {
+    if (state.finalised) return;
+    state.finalised = true;
+    state.writer.abort(cause);
+  };
+
+  return { addWorksheet, finalize, abort };
 };
+
+async function finalizeImpl(state: WorkbookState, writer: WorkbookState['writer']): Promise<void> {
+  // 1. Worksheets — already streamed through writer.addStreamingEntry
+  // during each WriteOnlyWorksheet's appendRow / close cycle.
+
+  // 2. Stylesheet.
+  await writer.addEntry(ARC_STYLE, stylesheetToBytes(state.styles));
+
+  // 3. SharedStrings (only when non-empty).
+  if (state.sst.entries.length > 0) {
+    await writer.addEntry(ARC_SHARED_STRINGS, sharedStringsToBytes(state.sst));
+  }
+
+  // 4. workbook.xml.
+  const workbookXml = serializeWorkbookXml(state.sheets);
+  await writer.addEntry(ARC_WORKBOOK, new TextEncoder().encode(workbookXml));
+
+  // 5. workbook.xml.rels.
+  const wbRels = makeRelationships();
+  state.sheets.forEach((s, i) => {
+    wbRels.rels.push({
+      id: `rId${i + 1}`,
+      type: `${REL_NS}/worksheet`,
+      target: `worksheets/sheet${s.sheetId}.xml`,
+    });
+  });
+  if (state.sst.entries.length > 0) {
+    wbRels.rels.push({
+      id: `rId${wbRels.rels.length + 1}`,
+      type: `${REL_NS}/sharedStrings`,
+      target: 'sharedStrings.xml',
+    });
+  }
+  wbRels.rels.push({
+    id: `rId${wbRels.rels.length + 1}`,
+    type: `${REL_NS}/styles`,
+    target: 'styles.xml',
+  });
+  await writer.addEntry(ARC_WORKBOOK_RELS, relsToBytes(wbRels));
+
+  // 6. root rels.
+  const rootRels = makeRelationships();
+  rootRels.rels.push({
+    id: 'rId1',
+    type: `${REL_NS}/officeDocument`,
+    target: 'xl/workbook.xml',
+  });
+  await writer.addEntry(ARC_ROOT_RELS, relsToBytes(rootRels));
+  void PKG_REL_NS; // imported for future docProps support
+
+  // 7. [Content_Types].xml.
+  const manifest = makeManifest();
+  // Excel rejects packages whose [Content_Types].xml is missing the Default
+  // entries for `rels` / `xml` — without them the package relationships file
+  // can't be classified and Excel refuses to open.
+  addDefault(manifest, 'rels', 'application/vnd.openxmlformats-package.relationships+xml');
+  addDefault(manifest, 'xml', 'application/xml');
+  addOverride(manifest, `/${ARC_WORKBOOK}`, XLSX_TYPE);
+  for (const s of state.sheets) {
+    addOverride(manifest, `/xl/worksheets/sheet${s.sheetId}.xml`, WORKSHEET_TYPE);
+  }
+  addOverride(manifest, `/${ARC_STYLE}`, STYLES_TYPE);
+  if (state.sst.entries.length > 0) {
+    addOverride(manifest, `/${ARC_SHARED_STRINGS}`, SHARED_STRINGS_TYPE);
+  }
+  await writer.addEntry(ARC_CONTENT_TYPES, manifestToBytes(manifest));
+
+  await writer.finalize();
+}
 
 const serializeWorkbookXml = (
   sheets: ReadonlyArray<{ title: string; sheetId: number }>,
@@ -396,10 +427,10 @@ export async function createWriteOnlyWorkbook(
   sink: XlsxSink,
   _opts: WriteOnlyOptions = {},
 ): Promise<WriteOnlyWorkbook> {
-  // The streaming-deflate ZIP writer is created lazily inside finalize() so the
-  // caller can compose multiple sheets without an early commit. Worksheet bytes
-  // accumulate in `state.sheets` until finalize streams them through fflate's
-  // `Zip` + `ZipDeflate` (see src/zip/writer.ts).
+  // The streaming-deflate ZIP writer is constructed eagerly here: each
+  // addWorksheet opens an entry on it and flushes row chunks through fflate's
+  // `Zip` + `ZipDeflate` immediately, so peak memory stays at one pending row
+  // buffer plus deflate scratch (no all-sheets accumulation).
   return makeWriteOnlyWorkbook(sink);
 }
 

--- a/src/utils/escape.ts
+++ b/src/utils/escape.ts
@@ -45,3 +45,42 @@ const UNESCAPE_RE = /_x([0-9A-Fa-f]{4})_/g;
 export function unescapeCellString(s: string): string {
   return s.replace(UNESCAPE_RE, (_full, hex: string) => String.fromCharCode(Number.parseInt(hex, 16)));
 }
+
+// ---- XML escape helpers ----------------------------------------------------
+//
+// One canonical implementation for text-node and attribute escaping. The
+// previous codebase carried three near-identical copies (one each in save.ts,
+// xml/serializer.ts, xml/stream-writer.ts); they disagreed about `>`-in-attribute
+// handling and would have drifted further apart over time. Keeping them in a
+// single place also makes future fixes (e.g. surrogate-pair scrubbing) land
+// once rather than three times.
+
+/**
+ * Escape a string for safe placement in an XML text node. Replaces the three
+ * codepoints that would otherwise terminate the text region or open a markup
+ * sequence (`&`, `<`, `>`); `"` and `'` are not legal markup terminators
+ * inside text and stay verbatim.
+ */
+export function escapeXmlText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Escape a string for safe placement inside a `"`-quoted XML attribute.
+ * Handles `&`, `<`, `>` and the `"` that would otherwise close the value.
+ *
+ * Note: this deliberately does NOT escape `\r` / `\n` / `\t` to numeric
+ * character references. XML 1.0 attribute-value normalisation would
+ * collapse them to spaces in theory, but the parser used on the read side
+ * (fast-xml-parser) does not decode numeric character references, so a
+ * write-then-read round-trip would surface the literal `&#9;` instead of
+ * recovering the original tab. Leaving the whitespace bytes literal keeps
+ * the round-trip stable and matches what Excel itself emits.
+ */
+export function escapeXmlAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/utils/utf8.ts
+++ b/src/utils/utf8.ts
@@ -17,13 +17,22 @@ export function utf8ByteLength(s: string): number {
     } else if (c < 0x800) {
       n += 2;
     } else if (c >= 0xd800 && c <= 0xdbff) {
-      // High surrogate: paired with the next code unit encodes one 4-byte
-      // codepoint. A lone high surrogate at the end of the string still
-      // produces 3 replacement bytes through TextEncoder; treat it as 4 here
-      // so the threshold check stays conservative.
-      n += 4;
-      i++;
+      // High surrogate. Only consume the next code unit when it actually
+      // is a low surrogate — an unpaired high surrogate (followed by a
+      // BMP char or by EOS) would otherwise swallow the next code unit
+      // and undercount the string. TextEncoder replaces a lone high
+      // surrogate with U+FFFD (3 bytes), so use 3 here too. A paired
+      // surrogate encodes one 4-byte codepoint.
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : 0;
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        n += 4;
+        i++;
+      } else {
+        n += 3;
+      }
     } else {
+      // Includes unpaired low surrogates (0xDC00-0xDFFF), which encode as
+      // U+FFFD = 3 UTF-8 bytes through TextEncoder.
       n += 3;
     }
   }

--- a/src/utils/utf8.ts
+++ b/src/utils/utf8.ts
@@ -1,0 +1,31 @@
+// Fast UTF-8 byte-length scan. Used by streaming writers to decide when their
+// pending string buffer should be encoded + flushed.
+//
+// `s.length` returns UTF-16 code units, which undercounts BMP characters above
+// U+007F (1 code unit, 2 UTF-8 bytes for U+0080–U+07FF, 3 bytes for the rest
+// of the BMP). For CJK-heavy payloads the discrepancy is ~3× — large enough
+// to push a "64 KB" flush threshold to 192 KB of resident text. We scan the
+// string once and account for each codepoint instead of running a full
+// TextEncoder, which would also have to materialise the byte buffer we don't
+// need yet.
+export function utf8ByteLength(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c < 0x80) {
+      n += 1;
+    } else if (c < 0x800) {
+      n += 2;
+    } else if (c >= 0xd800 && c <= 0xdbff) {
+      // High surrogate: paired with the next code unit encodes one 4-byte
+      // codepoint. A lone high surrogate at the end of the string still
+      // produces 3 replacement bytes through TextEncoder; treat it as 4 here
+      // so the threshold check stays conservative.
+      n += 4;
+      i++;
+    } else {
+      n += 3;
+    }
+  }
+  return n;
+}

--- a/src/workbook/shared-strings.ts
+++ b/src/workbook/shared-strings.ts
@@ -13,7 +13,7 @@
 
 import type { RichText } from '../cell/rich-text';
 import { type Color, colorToHex } from '../styles/colors';
-import { escapeCellString, unescapeCellString } from '../utils/escape';
+import { escapeCellString, escapeXmlAttr, escapeXmlText, unescapeCellString } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import { qname, SHEET_MAIN_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
@@ -223,14 +223,6 @@ export function serializeSharedStrings(table: SharedStringsTable): string {
   parts.push('</sst>');
   return parts.join('');
 }
-
-const escapeXmlText = (s: string): string =>
-  // Reorder so '&' is replaced first; otherwise we'd double-escape ampersands
-  // introduced by the later substitutions.
-  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-const escapeXmlAttr = (s: string): string =>
-  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
 
 const serializeSi = (value: SharedStringEntry): string => {
   if (typeof value === 'string') {

--- a/src/workbook/workbook.ts
+++ b/src/workbook/workbook.ts
@@ -480,14 +480,32 @@ export function renameSheet(wb: Workbook, oldTitle: string, newTitle: string): v
 }
 
 /**
- * Set the visibility state on a sheet by title. Throws on unknown title. Note:
- * Excel forbids hiding the active sheet when it's the only visible one — this
- * helper does NOT check that constraint; callers should ensure at least one
- * sheet stays visible.
+ * Set the visibility state on a sheet by title. Throws on unknown title.
+ * Refuses to hide the last visible sheet: an .xlsx with every sheet hidden
+ * fails to open in Excel ("Excel cannot use the object linking and embedding
+ * features because no sheet is visible"). Catching it here keeps the
+ * workbook recoverable instead of producing a save Excel will reject.
  */
 export function setSheetState(wb: Workbook, title: string, state: SheetState): void {
   const ref = wb.sheets.find((s) => s.sheet.title === title);
   if (!ref) throw new OpenXmlSchemaError(`setSheetState: no sheet named "${title}"`);
+  if (ref.state === state) return;
+  if (state !== 'visible' && ref.state === 'visible') {
+    let otherVisible = false;
+    for (const candidate of wb.sheets) {
+      if (candidate !== ref && candidate.state === 'visible') {
+        otherVisible = true;
+        break;
+      }
+    }
+    if (!otherVisible) {
+      throw new OpenXmlSchemaError(
+        `setSheetState: cannot hide "${title}" — it's the last visible sheet,` +
+          ' and Excel refuses to open a workbook with every sheet hidden. Make another sheet' +
+          ' visible first (or call showSheet()).',
+      );
+    }
+  }
   ref.state = state;
 }
 

--- a/src/workbook/workbook.ts
+++ b/src/workbook/workbook.ts
@@ -32,6 +32,7 @@ import type { LegacyComment } from '../worksheet/comments';
 import type { Hyperlink } from '../worksheet/hyperlinks';
 import type { CellsByKindCounts, Worksheet } from '../worksheet/worksheet';
 import {
+  classifyCellValue,
   countCellsByKind,
   getCell,
   getCellComment,
@@ -881,40 +882,84 @@ export interface WorkbookOverview {
 }
 
 export function describeWorkbook(wb: Workbook): WorkbookOverview {
-  const stats = getWorkbookStats(wb);
-  const cellsByKind = getWorkbookCellsByKind(wb);
+  // Single-pass aggregation: a cell-by-cell walk dominates this function's
+  // cost on million-cell workbooks, so we compute the workbook stats, the
+  // value-kind histogram, AND each sheet's cell/formula counts in one sweep
+  // instead of triple-scanning.
+  let worksheetCount = 0;
+  let chartsheetCount = 0;
+  let cellCount = 0;
+  let formulaCount = 0;
+  let commentCount = 0;
+  let hyperlinkCount = 0;
+  let mergedRangeCount = 0;
+  let tableCount = 0;
+  const cellsByKind: CellsByKindCounts = {
+    null: 0,
+    string: 0,
+    number: 0,
+    boolean: 0,
+    date: 0,
+    duration: 0,
+    error: 0,
+    'rich-text': 0,
+    formula: 0,
+  };
   const sheets: WorkbookSheetOverview[] = wb.sheets.map((ref) => {
-    if (ref.kind === 'worksheet') {
-      const ws = ref.sheet;
-      let formulaCount = 0;
-      let cellCount = 0;
-      for (const rowMap of ws.rows.values()) {
-        for (const cell of rowMap.values()) {
-          cellCount++;
-          if (isFormulaValue(cell.value)) formulaCount++;
-        }
-      }
+    if (ref.kind === 'chartsheet') {
+      chartsheetCount++;
       return {
-        title: ws.title,
-        kind: 'worksheet',
+        title: ref.sheet.title,
+        kind: 'chartsheet',
         state: ref.state,
-        cellCount,
-        formulaCount,
-        tableCount: ws.tables.length,
-        drawingItemCount: ws.drawing?.items.length ?? 0,
+        cellCount: 0,
+        formulaCount: 0,
+        tableCount: 0,
+        drawingItemCount: ref.sheet.drawing?.items.length ?? 0,
       };
     }
+    worksheetCount++;
+    const ws = ref.sheet;
+    let sheetCellCount = 0;
+    let sheetFormulaCount = 0;
+    for (const rowMap of ws.rows.values()) {
+      for (const cell of rowMap.values()) {
+        sheetCellCount++;
+        const bucket = classifyCellValue(cell.value);
+        cellsByKind[bucket]++;
+        if (isFormulaValue(cell.value)) sheetFormulaCount++;
+      }
+    }
+    cellCount += sheetCellCount;
+    formulaCount += sheetFormulaCount;
+    commentCount += ws.legacyComments.length;
+    hyperlinkCount += ws.hyperlinks.length;
+    mergedRangeCount += ws.mergedCells.length;
+    tableCount += ws.tables.length;
     return {
-      title: ref.sheet.title,
-      kind: 'chartsheet',
+      title: ws.title,
+      kind: 'worksheet',
       state: ref.state,
-      cellCount: 0,
-      formulaCount: 0,
-      tableCount: 0,
-      drawingItemCount: ref.sheet.drawing?.items.length ?? 0,
+      cellCount: sheetCellCount,
+      formulaCount: sheetFormulaCount,
+      tableCount: ws.tables.length,
+      drawingItemCount: ws.drawing?.items.length ?? 0,
     };
   });
-  return { ...stats, cellsByKind, sheets };
+  return {
+    worksheetCount,
+    chartsheetCount,
+    cellCount,
+    formulaCount,
+    commentCount,
+    hyperlinkCount,
+    mergedRangeCount,
+    tableCount,
+    definedNameCount: wb.definedNames.length,
+    customPropertyCount: wb.customProperties?.properties.length ?? 0,
+    cellsByKind,
+    sheets,
+  };
 }
 
 /**

--- a/src/worksheet/comments-xml.ts
+++ b/src/worksheet/comments-xml.ts
@@ -1,5 +1,6 @@
 // xl/commentsN.xml read/write.
 
+import { escapeXmlAttr, escapeXmlText } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import { SHEET_MAIN_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
@@ -19,8 +20,8 @@ const R_TAG = `{${SHEET_MAIN_NS}}r`;
 
 const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
-const escapeText = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-const escapeAttr = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+const escapeText = escapeXmlText;
+const escapeAttr = escapeXmlAttr;
 
 /** Concatenate every `<t>` text node found inside a `<text>` body. */
 const collectText = (textEl: XmlNode): string => {

--- a/src/worksheet/conditional-formatting.ts
+++ b/src/worksheet/conditional-formatting.ts
@@ -7,6 +7,7 @@
 // survives a save / load cycle without our needing to model cfvo / colors /
 // iconSets fully.
 
+import { escapeXmlAttr } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import { type MultiCellRange, parseMultiCellRange } from './cell-range';
 
@@ -333,8 +334,7 @@ export type IconSetStyle =
   | '5Quarters'
   | '5Rating';
 
-const escapeAttr = (s: string): string =>
-  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+const escapeAttr = escapeXmlAttr;
 
 const renderCfvo = (c: Cfvo): string => {
   if (c.type === 'min' || c.type === 'max') {

--- a/src/worksheet/table-xml.ts
+++ b/src/worksheet/table-xml.ts
@@ -4,6 +4,7 @@
 // and conditional, and we want minimum bundle weight. Pairs with the
 // loader/writer wiring in src/public/{load,save}.ts.
 
+import { escapeXmlAttr } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import { SHEET_MAIN_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
@@ -23,7 +24,7 @@ const FILTER_TAG = `{${SHEET_MAIN_NS}}filter`;
 
 const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
-const escapeAttr = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+const escapeAttr = escapeXmlAttr;
 
 const parseBool = (v: string | undefined): boolean | undefined => {
   if (v === undefined) return undefined;

--- a/src/worksheet/worksheet.ts
+++ b/src/worksheet/worksheet.ts
@@ -561,6 +561,25 @@ export interface CellsByKindCounts {
   formula: number;
 }
 
+/**
+ * Bucket a single CellValue into one of the {@link CellsByKindCounts} keys.
+ * Shared between {@link countCellsByKind} and the workbook-wide overview so
+ * the two never drift in how they classify (e.g. `Date` vs `duration`).
+ */
+export function classifyCellValue(v: import('../cell/cell').CellValue): keyof CellsByKindCounts {
+  if (v === null) return 'null';
+  if (typeof v === 'string') return 'string';
+  if (typeof v === 'number') return 'number';
+  if (typeof v === 'boolean') return 'boolean';
+  if (v instanceof Date) return 'date';
+  const kind = (v as { kind?: string }).kind;
+  if (kind === 'duration') return 'duration';
+  if (kind === 'error') return 'error';
+  if (kind === 'rich-text') return 'rich-text';
+  // Remaining shape is FormulaValue (kind === 'formula').
+  return 'formula';
+}
+
 export function countCellsByKind(ws: Worksheet): CellsByKindCounts {
   const out: CellsByKindCounts = {
     null: 0,
@@ -574,19 +593,7 @@ export function countCellsByKind(ws: Worksheet): CellsByKindCounts {
     formula: 0,
   };
   for (const cell of iterCells(ws)) {
-    const v = cell.value;
-    if (v === null) out.null++;
-    else if (typeof v === 'string') out.string++;
-    else if (typeof v === 'number') out.number++;
-    else if (typeof v === 'boolean') out.boolean++;
-    else if (v instanceof Date) out.date++;
-    else {
-      const kind = (v as { kind?: string }).kind;
-      if (kind === 'duration') out.duration++;
-      else if (kind === 'error') out.error++;
-      else if (kind === 'rich-text') out['rich-text']++;
-      else if (kind === 'formula') out.formula++;
-    }
+    out[classifyCellValue(cell.value)]++;
   }
   return out;
 }
@@ -1386,9 +1393,18 @@ export function getRowValues(
     if (opts.minCol === undefined && opts.maxCol === undefined) return [];
   }
   const minCol = opts.minCol ?? 1;
-  const maxCol =
-    opts.maxCol ??
-    (rowMap ? Math.max(...rowMap.keys()) : 0);
+  // Manual scan avoids `Math.max(...rowMap.keys())`. Spread into a builtin is
+  // limited by the engine's argument-count cap (~125 k on V8), and `getRowValues`
+  // is documented to handle every column up to MAX_COL (16384). For sparse
+  // rows the spread is fine in practice; for dense rows it would silently
+  // throw a stack overflow — surface the cost in a single linear scan instead.
+  let derivedMax = 0;
+  if (rowMap && opts.maxCol === undefined) {
+    for (const c of rowMap.keys()) {
+      if (c > derivedMax) derivedMax = c;
+    }
+  }
+  const maxCol = opts.maxCol ?? derivedMax;
   if (maxCol < minCol) return [];
   const out: (CellValue | null)[] = [];
   for (let c = minCol; c <= maxCol; c++) {

--- a/src/worksheet/worksheet.ts
+++ b/src/worksheet/worksheet.ts
@@ -1256,6 +1256,7 @@ export function copyRange(
   opts: { targetWs?: Worksheet } = {},
 ): number {
   const dest = opts.targetWs ?? ws;
+  const sameSheet = dest === ws;
   const src = parseRange(source);
   const dst = parseRange(target);
   const dr = dst.minRow - src.minRow;
@@ -1272,8 +1273,16 @@ export function copyRange(
       const dstRow = src.minRow + i + dr;
       const dstCol = src.minCol + j + dc;
       const newCell = setCell(dest, dstRow, dstCol, srcCell.value, srcCell.styleId);
-      if (srcCell.hyperlinkId !== undefined) newCell.hyperlinkId = srcCell.hyperlinkId;
-      if (srcCell.commentId !== undefined) newCell.commentId = srcCell.commentId;
+      // hyperlinkId / commentId index into the *source* worksheet's
+      // `hyperlinks` / `legacyComments` arrays. Carrying them across sheets
+      // would point at unrelated entries on the destination (or a missing
+      // slot), so we keep them only on a same-sheet copy. The actual link /
+      // comment records aren't part of the copied range — callers needing
+      // cross-sheet link semantics should re-issue setHyperlink on the dest.
+      if (sameSheet) {
+        if (srcCell.hyperlinkId !== undefined) newCell.hyperlinkId = srcCell.hyperlinkId;
+        if (srcCell.commentId !== undefined) newCell.commentId = srcCell.commentId;
+      }
       n++;
     }
   }
@@ -1295,6 +1304,7 @@ export function moveRange(
   opts: { targetWs?: Worksheet } = {},
 ): number {
   const dest = opts.targetWs ?? ws;
+  const sameSheet = dest === ws;
   const src = parseRange(source);
   const dst = parseRange(target);
   const dr = dst.minRow - src.minRow;
@@ -1322,15 +1332,19 @@ export function moveRange(
     for (let j = 0; j <= maxColOffset; j++) srcRow.delete(src.minCol + j);
     if (srcRow.size === 0) ws.rows.delete(rowIdx);
   }
-  // Replay the snapshot into the destination — value, styleId, and optional
-  // hyperlinkId / commentId.
+  // Replay the snapshot into the destination — value, styleId, and (only on
+  // a same-sheet move) hyperlinkId / commentId. See copyRange for the
+  // cross-sheet rationale: those indexes are scoped to the source sheet's
+  // own hyperlink / comment arrays and don't translate.
   for (const entry of snap) {
     const { row, col, cell } = entry;
     const dstRow = row + dr;
     const dstCol = col + dc;
     const newCell = setCell(dest, dstRow, dstCol, cell.value, cell.styleId);
-    if (cell.hyperlinkId !== undefined) newCell.hyperlinkId = cell.hyperlinkId;
-    if (cell.commentId !== undefined) newCell.commentId = cell.commentId;
+    if (sameSheet) {
+      if (cell.hyperlinkId !== undefined) newCell.hyperlinkId = cell.hyperlinkId;
+      if (cell.commentId !== undefined) newCell.commentId = cell.commentId;
+    }
   }
   return snap.length;
 }

--- a/src/worksheet/writer.ts
+++ b/src/worksheet/writer.ts
@@ -12,7 +12,7 @@
 import { type Cell, type CellValue, type ExcelErrorCode, type FormulaValue, getCoordinate } from '../cell/cell';
 import type { Relationships } from '../packaging/relationships';
 import { dateToExcel, durationToExcel } from '../utils/datetime';
-import { escapeCellString } from '../utils/escape';
+import { escapeCellString, escapeXmlAttr as escapeXmlAttrShared, escapeXmlText as escapeXmlTextShared } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import type { SharedStringsTable } from '../workbook/shared-strings';
 import { addSharedString, serializeRichTextRuns } from '../workbook/shared-strings';
@@ -238,9 +238,8 @@ function serializeWorksheet(ws: Worksheet, ctx: WorksheetWriteContext): string {
   return parts.join('');
 }
 
-const escapeXmlText = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-const escapeXmlAttr = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+const escapeXmlText = escapeXmlTextShared;
+const escapeXmlAttr = escapeXmlAttrShared;
 
 const serializeDimension = (ws: Worksheet): string => {
   let minRow = Infinity;
@@ -953,32 +952,37 @@ const serializeIgnoredErrors = (errs: ReadonlyArray<IgnoredError>): string => {
 
 const serializeHyperlinks = (links: ReadonlyArray<Hyperlink>, rels: Relationships | undefined): string => {
   const parts: string[] = ['<hyperlinks>'];
+  // Index existing rels once so the per-hyperlink rId allocation + dedup checks
+  // don't degrade to O(N²) on worksheets with many hyperlinks (dashboard /
+  // index sheets routinely carry hundreds).
+  const claimedIds = rels ? new Set<string>(rels.rels.map((r) => r.id)) : undefined;
+  let rIdCursor = rels ? rels.rels.length + 1 : 1;
   for (const link of links) {
     let attrs = ` ref="${escapeXmlAttr(link.ref)}"`;
     if (link.target !== undefined) {
       // Allocate or reuse a rels entry. We need rels to host external URLs;
       // when ctx.rels is missing we fall back to inlining via location only.
-      if (rels) {
+      if (rels && claimedIds) {
         let rId = link.rId;
         if (!rId) {
-          // Find the next free rIdN that doesn't already exist on this sheet's
-          // rels. Pre-loaded relsExtras can occupy low-numbered ids; a naive
-          // `rId${len+1}` would collide.
-          let n = rels.rels.length + 1;
-          rId = `rId${n}`;
-          while (rels.rels.some((r) => r.id === rId)) {
-            n++;
-            rId = `rId${n}`;
+          // Find the next free rIdN. Pre-loaded relsExtras can occupy
+          // low-numbered ids; advance the cursor past anything already in use.
+          rId = `rId${rIdCursor}`;
+          while (claimedIds.has(rId)) {
+            rIdCursor++;
+            rId = `rId${rIdCursor}`;
           }
+          rIdCursor++;
         }
         // Add rel only if no entry already targets this URL (conservative).
-        if (!rels.rels.some((r) => r.id === rId)) {
+        if (!claimedIds.has(rId)) {
           rels.rels.push({
             id: rId,
             type: HYPERLINK_REL_TYPE,
             target: link.target,
             targetMode: 'External',
           });
+          claimedIds.add(rId);
         }
         attrs += ` r:id="${escapeXmlAttr(rId)}"`;
       }

--- a/src/xml/iterparse.ts
+++ b/src/xml/iterparse.ts
@@ -85,7 +85,14 @@ export async function* iterParse(input: SaxInput): AsyncIterableIterator<SaxEven
   // every open / close tag and on every attribute.
   const parser = new SaxesParser({ xmlns: true, fragment: false });
 
-  const queue: SaxEvent[] = [];
+  // Head-pointer ring instead of Array#shift: each saxes write() can produce
+  // hundreds of events in a single synchronous batch (a `<row>` with dozens of
+  // cells flushes one opentag + one text + one closetag per cell). `shift()`
+  // is O(n) per element in V8, so a single-batch drain of N events would be
+  // O(N²) before iteration. The head advances on yield; the queue is reset
+  // (head + length) once it drains so memory stays bounded.
+  let queue: SaxEvent[] = [];
+  let head = 0;
   let pending: Error | undefined;
 
   parser.on('error', (err: Error) => {
@@ -106,8 +113,14 @@ export async function* iterParse(input: SaxInput): AsyncIterableIterator<SaxEven
 
   const drain = function* (): IterableIterator<SaxEvent> {
     for (;;) {
-      const ev = queue.shift();
-      if (ev === undefined) return;
+      const ev = head < queue.length ? queue[head] : undefined;
+      if (ev === undefined) {
+        // Reset rather than grow forever; the next batch starts at index 0.
+        queue = [];
+        head = 0;
+        return;
+      }
+      head++;
       yield ev;
     }
   };
@@ -136,9 +149,12 @@ export async function* iterParse(input: SaxInput): AsyncIterableIterator<SaxEven
       const chunk = td.decode(value, { stream: true });
       if (!firstChunkChecked) {
         // We need to see enough of the prologue to be sure no DOCTYPE is
-        // hiding. Buffer until we have ~256 chars or the stream ends.
+        // hiding. Buffer until we have ~256 chars; if the stream ends before
+        // we reach the threshold the tail handler below runs `checkDoctype`
+        // on the accumulated prologue. (The previous `|| done` here was dead:
+        // a true `done` short-circuits at the top of the loop.)
         firstChunkBuffer += chunk;
-        if (firstChunkBuffer.length >= 256 || done) {
+        if (firstChunkBuffer.length >= 256) {
           checkDoctype(firstChunkBuffer);
           firstChunkChecked = true;
           feed(firstChunkBuffer);

--- a/src/xml/serializer.ts
+++ b/src/xml/serializer.ts
@@ -17,6 +17,7 @@
 // `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` on its own
 // line, attribute values quoted with `"`.
 
+import { escapeXmlAttr, escapeXmlText } from '../utils/escape';
 import { DEFAULT_PREFIXES, parseQName, XML_NS } from './namespaces';
 import type { XmlNode } from './tree';
 
@@ -152,31 +153,19 @@ const buildAttrPrefix = (name: string, prefixOf: Map<string, string>): string =>
   return `${prefix}:${local}`;
 };
 
-const escapeText = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-const escapeAttr = (s: string): string =>
-  s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/\r/g, '&#13;')
-    .replace(/\n/g, '&#10;')
-    .replace(/\t/g, '&#9;');
-
 const emit = (out: string[], node: XmlNode, allocation: Allocation, isRoot: boolean): void => {
   const tag = buildElementPrefix(node.name, allocation.prefixOf);
   out.push('<', tag);
 
   if (isRoot) {
     for (const { prefix, ns } of allocation.declarations) {
-      out.push(prefix === '' ? ` xmlns="${escapeAttr(ns)}"` : ` xmlns:${prefix}="${escapeAttr(ns)}"`);
+      out.push(prefix === '' ? ` xmlns="${escapeXmlAttr(ns)}"` : ` xmlns:${prefix}="${escapeXmlAttr(ns)}"`);
     }
   }
 
   for (const [name, value] of Object.entries(node.attrs)) {
     const attrName = buildAttrPrefix(name, allocation.prefixOf);
-    out.push(' ', attrName, '="', escapeAttr(value), '"');
+    out.push(' ', attrName, '="', escapeXmlAttr(value), '"');
   }
 
   const text = node.text;
@@ -188,7 +177,7 @@ const emit = (out: string[], node: XmlNode, allocation: Allocation, isRoot: bool
   }
 
   out.push('>');
-  if (hasText) out.push(escapeText(text));
+  if (hasText) out.push(escapeXmlText(text));
   for (const c of node.children) emit(out, c, allocation, /* isRoot */ false);
   out.push('</', tag, '>');
 };

--- a/src/xml/stream-writer.ts
+++ b/src/xml/stream-writer.ts
@@ -11,7 +11,9 @@
 // this writer's start / end / writeNode methods. Use `writeRaw` to splice those
 // in.
 
+import { escapeXmlAttr, escapeXmlText } from '../utils/escape';
 import { OpenXmlIoError } from '../utils/exceptions';
+import { utf8ByteLength } from '../utils/utf8';
 import { DEFAULT_PREFIXES, parseQName, XML_NS } from './namespaces';
 import type { XmlNode } from './tree';
 
@@ -57,17 +59,6 @@ export interface XmlStreamWriter {
 const DEFAULT_FLUSH_BYTES = 64 * 1024;
 const encoder = new TextEncoder();
 
-const escapeText = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-const escapeAttr = (s: string): string =>
-  s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/\r/g, '&#13;')
-    .replace(/\n/g, '&#10;')
-    .replace(/\t/g, '&#9;');
-
 const buildPrefixMap = (user: Readonly<Record<string, string>> | undefined): Map<string, string> => {
   const out = new Map<string, string>();
   for (const [ns, prefix] of Object.entries(DEFAULT_PREFIXES)) out.set(ns, prefix);
@@ -85,9 +76,18 @@ export function createXmlStreamWriter(opts: XmlStreamWriterOptions = {}): XmlStr
 
   const chunks: Uint8Array[] = [];
   let buf = '';
+  // Running UTF-8 byte count of `buf`, maintained incrementally via `append()`.
+  // Without this the flush threshold compares UTF-16 code units against a
+  // byte budget — non-ASCII payloads then balloon past the configured limit.
+  let bufBytes = 0;
   let openStartTag = false;
   let finalised = false;
   const stack: string[] = [];
+
+  const append = (s: string): void => {
+    buf += s;
+    bufBytes += utf8ByteLength(s);
+  };
 
   const elementName = (name: string): string => {
     const { ns, local } = parseQName(name);
@@ -108,22 +108,23 @@ export function createXmlStreamWriter(opts: XmlStreamWriterOptions = {}): XmlStr
     if (buf.length === 0) return;
     chunks.push(encoder.encode(buf));
     buf = '';
+    bufBytes = 0;
   };
 
   const maybeFlush = (): void => {
-    if (buf.length >= flushBytes) flushImpl();
+    if (bufBytes >= flushBytes) flushImpl();
   };
 
   const closeStartTagIfOpen = (): void => {
     if (!openStartTag) return;
-    buf += '>';
+    append('>');
     openStartTag = false;
   };
 
   if (xmlDeclaration) {
-    buf += '<?xml version="1.0" encoding="UTF-8"';
-    if (standalone !== 'omit') buf += ` standalone="${standalone}"`;
-    buf += '?>\n';
+    append('<?xml version="1.0" encoding="UTF-8"');
+    if (standalone !== 'omit') append(` standalone="${standalone}"`);
+    append('?>\n');
   }
 
   // ---- writeNode internals
@@ -131,21 +132,21 @@ export function createXmlStreamWriter(opts: XmlStreamWriterOptions = {}): XmlStr
 
   const emitNodeInline = (n: XmlNode): void => {
     const tag = elementName(n.name);
-    buf += `<${tag}`;
+    append(`<${tag}`);
     for (const [name, value] of Object.entries(n.attrs)) {
-      buf += ` ${attributeName(name)}="${escapeAttr(value)}"`;
+      append(` ${attributeName(name)}="${escapeXmlAttr(value)}"`);
     }
     const text = n.text;
     const hasText = text !== undefined && text !== '';
     const hasChildren = n.children.length > 0;
     if (!hasText && !hasChildren) {
-      buf += '/>';
+      append('/>');
       return;
     }
-    buf += '>';
-    if (hasText) buf += escapeText(text);
+    append('>');
+    if (hasText) append(escapeXmlText(text));
     for (const c of n.children) emitNodeInline(c);
-    buf += `</${tag}>`;
+    append(`</${tag}>`);
   };
 
   // ---- public surface
@@ -156,10 +157,10 @@ export function createXmlStreamWriter(opts: XmlStreamWriterOptions = {}): XmlStr
       if (finalised) throw new OpenXmlIoError('XmlStreamWriter: start() after result()');
       closeStartTagIfOpen();
       const tag = elementName(name);
-      buf += `<${tag}`;
+      append(`<${tag}`);
       if (attrs !== undefined) {
         for (const [k, v] of Object.entries(attrs)) {
-          buf += ` ${attributeName(k)}="${escapeAttr(v)}"`;
+          append(` ${attributeName(k)}="${escapeXmlAttr(v)}"`);
         }
       }
       stack.push(tag);
@@ -169,7 +170,7 @@ export function createXmlStreamWriter(opts: XmlStreamWriterOptions = {}): XmlStr
     text(s) {
       if (finalised) throw new OpenXmlIoError('XmlStreamWriter: text() after result()');
       closeStartTagIfOpen();
-      buf += escapeText(s);
+      append(escapeXmlText(s));
       maybeFlush();
     },
     writeNode(n) {
@@ -181,7 +182,7 @@ export function createXmlStreamWriter(opts: XmlStreamWriterOptions = {}): XmlStr
     writeRaw(s) {
       if (finalised) throw new OpenXmlIoError('XmlStreamWriter: writeRaw() after result()');
       closeStartTagIfOpen();
-      buf += s;
+      append(s);
       maybeFlush();
     },
     end() {
@@ -189,10 +190,10 @@ export function createXmlStreamWriter(opts: XmlStreamWriterOptions = {}): XmlStr
       const tag = stack.pop();
       if (tag === undefined) throw new OpenXmlIoError('XmlStreamWriter: end() with no open element');
       if (openStartTag) {
-        buf += '/>';
+        append('/>');
         openStartTag = false;
       } else {
-        buf += `</${tag}>`;
+        append(`</${tag}>`);
       }
       maybeFlush();
     },

--- a/src/zip/random-access-reader.ts
+++ b/src/zip/random-access-reader.ts
@@ -151,16 +151,30 @@ function readZip64Extra(
   wantsUncompSize: boolean,
   wantsCompSize: boolean,
   wantsLfhOffset: boolean,
+  entryPath: string,
 ): { uncompSize?: number; compSize?: number; lfhOffset?: number } {
   let p = extraStart;
   const end = extraStart + extraLen;
   while (p + 4 <= end) {
     const id = u16(b, p);
     const size = u16(b, p + 2);
-    const next = p + 4 + size;
+    const dataStart = p + 4;
+    const next = dataStart + size;
     if (next > end) break;
     if (id === ZIP64_EXTRA_HEADER_ID) {
-      let q = p + 4;
+      // Sanity-check that the declared extra-field size actually covers every
+      // u64 the CD asked us to read. A truncated / mis-sized ZIP64 extra
+      // field would otherwise let u64() interpret bytes belonging to the
+      // next extra record (or the next CD entry) as a size/offset, producing
+      // bogus values that downstream bomb checks then trust. Fail closed.
+      const needed = (wantsUncompSize ? 8 : 0) + (wantsCompSize ? 8 : 0) + (wantsLfhOffset ? 8 : 0);
+      if (size < needed) {
+        throw new OpenXmlIoError(
+          `openZip: ZIP64 extended-info field for "${entryPath}" declares ${size} bytes` +
+            ` but the central directory sentinels require ${needed}`,
+        );
+      }
+      let q = dataStart;
       const result: { uncompSize?: number; compSize?: number; lfhOffset?: number } = {};
       if (wantsUncompSize) {
         result.uncompSize = u64(b, q);
@@ -211,7 +225,7 @@ function parseCentralDirectory(b: Uint8Array, cdOffset: number, expectedCount: n
     const wantsComp = compSize === ZIP32_MAX_U32;
     const wantsOffset = lfhOffset === ZIP32_MAX_U32;
     if (wantsUncomp || wantsComp || wantsOffset) {
-      const extra = readZip64Extra(b, p + 46 + nameLen, extraLen, wantsUncomp, wantsComp, wantsOffset);
+      const extra = readZip64Extra(b, p + 46 + nameLen, extraLen, wantsUncomp, wantsComp, wantsOffset, path);
       if (extra.uncompSize !== undefined) uncompSize = extra.uncompSize;
       if (extra.compSize !== undefined) compSize = extra.compSize;
       if (extra.lfhOffset !== undefined) lfhOffset = extra.lfhOffset;
@@ -264,21 +278,44 @@ export function openRandomAccessArchive(
 
   const resolvedLimits = resolveDecompressionLimits(decompressionLimits);
 
+  // Detect ZIP64 up front so a malformed ZIP64 record fails closed instead of
+  // falling back to `unzipSync`. The fallback inflates every entry before any
+  // bomb cap runs; the whole point of the ZIP64 path is to keep the streaming
+  // caps in play, so we must not silently downgrade when ZIP64 is in use.
+  const eocdTotalEntries = u16(bytes, eocdOff + 10);
+  const eocdCdSize = u32(bytes, eocdOff + 12);
+  const eocdCdOffset = u32(bytes, eocdOff + 16);
+  const claimsZip64 =
+    eocdTotalEntries === ZIP32_MAX_U16 ||
+    eocdCdSize === ZIP32_MAX_U32 ||
+    eocdCdOffset === ZIP32_MAX_U32;
+
   let summary: CdSummary;
   try {
     summary = readCdSummary(bytes, eocdOff);
-  } catch {
-    // Malformed EOCD / ZIP64 layout — fall back to fflate, which is more
-    // tolerant about archive quirks. The fallback still pre-checks declared
-    // entry sizes; see openViaUnzipSync.
+  } catch (cause) {
+    if (claimsZip64) {
+      // ZIP64 sentinels are set but the matching record / locator is missing
+      // or invalid. Fail closed — `unzipSync` would inflate every entry.
+      throw cause instanceof OpenXmlIoError
+        ? cause
+        : new OpenXmlIoError('openZip: ZIP64 central directory is malformed', { cause });
+    }
+    // Plain ZIP32 with an unparseable EOCD — fflate's `unzipSync` is more
+    // tolerant of quirky archives; the post-hoc bomb check still applies.
     return openViaUnzipSync(bytes, resolvedLimits);
   }
 
   let entries: CdEntry[];
   try {
     entries = parseCentralDirectory(bytes, summary.cdOffset, summary.totalEntries);
-  } catch {
-    // Malformed CD — fall back to fflate which is more tolerant.
+  } catch (cause) {
+    if (claimsZip64) {
+      throw cause instanceof OpenXmlIoError
+        ? cause
+        : new OpenXmlIoError('openZip: ZIP64 central directory is malformed', { cause });
+    }
+    // Malformed ZIP32 CD — fall back to fflate which is more tolerant.
     return openViaUnzipSync(bytes, resolvedLimits);
   }
 

--- a/src/zip/random-access-reader.ts
+++ b/src/zip/random-access-reader.ts
@@ -47,6 +47,12 @@ const singleChunkStream = (bytes: Uint8Array): ReadableStream<Uint8Array> =>
 const SIG_EOCD = 0x06054b50;
 const SIG_CD = 0x02014b50;
 const SIG_LFH = 0x04034b50;
+const SIG_ZIP64_EOCD = 0x06064b50;
+const SIG_ZIP64_EOCD_LOCATOR = 0x07064b50;
+const ZIP32_MAX_U16 = 0xffff;
+const ZIP32_MAX_U32 = 0xffffffff;
+const ZIP64_LOCATOR_SIZE = 20;
+const ZIP64_EXTRA_HEADER_ID = 0x0001;
 const COMP_STORE = 0;
 const COMP_DEFLATE = 8;
 
@@ -69,6 +75,20 @@ const u32 = (b: Uint8Array, off: number): number => {
   return (v0 | (v1 << 8) | (v2 << 16) | (v3 << 24)) >>> 0;
 };
 
+// Read a little-endian 64-bit value as a JS Number. Safe for values up to
+// 2^53-1 (Number.MAX_SAFE_INTEGER ~ 9 PiB), which is well past any realistic
+// xlsx archive — we throw if a parsed value exceeds the safe-integer range.
+const u64 = (b: Uint8Array, off: number): number => {
+  const lo = u32(b, off);
+  const hi = u32(b, off + 4);
+  if (hi > 0x1fffff) {
+    throw new OpenXmlIoError(
+      `openZip: ZIP64 field at byte ${off} exceeds the safe-integer range (${hi}*2^32 + ${lo})`,
+    );
+  }
+  return hi * 0x100000000 + lo;
+};
+
 /** Find the End-of-Central-Directory record by scanning backwards from EOF. */
 function findEocd(b: Uint8Array): number {
   const minStart = Math.max(0, b.length - 22 - 0xffff);
@@ -76,6 +96,89 @@ function findEocd(b: Uint8Array): number {
     if (u32(b, i) === SIG_EOCD) return i;
   }
   throw new OpenXmlIoError('openZip: no End-of-Central-Directory signature found');
+}
+
+interface CdSummary {
+  totalEntries: number;
+  cdSize: number;
+  cdOffset: number;
+}
+
+/**
+ * Resolve the central-directory totals. When the EOCD carries ZIP64 sentinel
+ * values (0xFFFF / 0xFFFFFFFF) the real totals live in a ZIP64 EOCD record
+ * located via the ZIP64 EOCD locator just before the regular EOCD. ECMA-376
+ * xlsx archives stay in ZIP32 territory; the ZIP64 path exists so the
+ * decompression-bomb guards still apply to large external archives instead of
+ * falling all the way back to `unzipSync` (which produces every entry's bytes
+ * before any cap can fire).
+ */
+function readCdSummary(b: Uint8Array, eocdOff: number): CdSummary {
+  let totalEntries = u16(b, eocdOff + 10);
+  let cdSize = u32(b, eocdOff + 12);
+  let cdOffset = u32(b, eocdOff + 16);
+
+  const usesZip64Eocd =
+    totalEntries === ZIP32_MAX_U16 || cdSize === ZIP32_MAX_U32 || cdOffset === ZIP32_MAX_U32;
+  if (!usesZip64Eocd) {
+    return { totalEntries, cdSize, cdOffset };
+  }
+
+  // Locate the ZIP64 EOCD locator. It sits immediately before the regular
+  // EOCD when one is present.
+  const locatorOff = eocdOff - ZIP64_LOCATOR_SIZE;
+  if (locatorOff < 0 || u32(b, locatorOff) !== SIG_ZIP64_EOCD_LOCATOR) {
+    throw new OpenXmlIoError('openZip: ZIP64 EOCD locator missing despite EOCD sentinel values');
+  }
+  const zip64EocdOff = u64(b, locatorOff + 8);
+  if (zip64EocdOff < 0 || zip64EocdOff + 56 > b.length) {
+    throw new OpenXmlIoError(`openZip: ZIP64 EOCD offset ${zip64EocdOff} out of bounds`);
+  }
+  if (u32(b, zip64EocdOff) !== SIG_ZIP64_EOCD) {
+    throw new OpenXmlIoError(`openZip: ZIP64 EOCD signature missing at byte ${zip64EocdOff}`);
+  }
+  totalEntries = u64(b, zip64EocdOff + 32);
+  cdSize = u64(b, zip64EocdOff + 40);
+  cdOffset = u64(b, zip64EocdOff + 48);
+  return { totalEntries, cdSize, cdOffset };
+}
+
+/** Walk the ZIP64 Extended Information extra field for sentinel-valued sizes/offset. */
+function readZip64Extra(
+  b: Uint8Array,
+  extraStart: number,
+  extraLen: number,
+  wantsUncompSize: boolean,
+  wantsCompSize: boolean,
+  wantsLfhOffset: boolean,
+): { uncompSize?: number; compSize?: number; lfhOffset?: number } {
+  let p = extraStart;
+  const end = extraStart + extraLen;
+  while (p + 4 <= end) {
+    const id = u16(b, p);
+    const size = u16(b, p + 2);
+    const next = p + 4 + size;
+    if (next > end) break;
+    if (id === ZIP64_EXTRA_HEADER_ID) {
+      let q = p + 4;
+      const result: { uncompSize?: number; compSize?: number; lfhOffset?: number } = {};
+      if (wantsUncompSize) {
+        result.uncompSize = u64(b, q);
+        q += 8;
+      }
+      if (wantsCompSize) {
+        result.compSize = u64(b, q);
+        q += 8;
+      }
+      if (wantsLfhOffset) {
+        result.lfhOffset = u64(b, q);
+        q += 8;
+      }
+      return result;
+    }
+    p = next;
+  }
+  return {};
 }
 
 /** Parse the central directory into an array of entry descriptors. */
@@ -88,17 +191,31 @@ function parseCentralDirectory(b: Uint8Array, cdOffset: number, expectedCount: n
     }
     const gpFlag = u16(b, p + 8);
     const compMethod = u16(b, p + 10);
-    const compSize = u32(b, p + 20);
-    const uncompSize = u32(b, p + 24);
+    let compSize = u32(b, p + 20);
+    let uncompSize = u32(b, p + 24);
     const nameLen = u16(b, p + 28);
     const extraLen = u16(b, p + 30);
     const commentLen = u16(b, p + 32);
-    const lfhOffset = u32(b, p + 42);
+    let lfhOffset = u32(b, p + 42);
     const nameBytes = b.subarray(p + 46, p + 46 + nameLen);
     // Bit 11 (0x0800) signals UTF-8 filename. xlsx archives are almost always
     // UTF-8 already; treat bit-0 as UTF-8 too since CP437 ⊃ ASCII and xlsx uses
     // ASCII paths.
     const path = new TextDecoder('utf-8').decode(nameBytes);
+
+    // ZIP64 Extended Information rewrites whichever of {uncompSize, compSize,
+    // lfhOffset} are 0xFFFFFFFF sentinels in the canonical fields. The extra
+    // field stores them in the order listed in the spec (and omits any that
+    // weren't sentinels), so we have to track which slots to read.
+    const wantsUncomp = uncompSize === ZIP32_MAX_U32;
+    const wantsComp = compSize === ZIP32_MAX_U32;
+    const wantsOffset = lfhOffset === ZIP32_MAX_U32;
+    if (wantsUncomp || wantsComp || wantsOffset) {
+      const extra = readZip64Extra(b, p + 46 + nameLen, extraLen, wantsUncomp, wantsComp, wantsOffset);
+      if (extra.uncompSize !== undefined) uncompSize = extra.uncompSize;
+      if (extra.compSize !== undefined) compSize = extra.compSize;
+      if (extra.lfhOffset !== undefined) lfhOffset = extra.lfhOffset;
+    }
     entries.push({ path, lfhOffset, compMethod, compSize, uncompSize, gpFlag });
     p += 46 + nameLen + extraLen + commentLen;
   }
@@ -145,20 +262,21 @@ export function openRandomAccessArchive(
     throw new OpenXmlIoError('openZip: archive is not a valid zip', { cause });
   }
 
-  const totalEntries = u16(bytes, eocdOff + 10);
-  const cdSize = u32(bytes, eocdOff + 12);
-  const cdOffset = u32(bytes, eocdOff + 16);
-
   const resolvedLimits = resolveDecompressionLimits(decompressionLimits);
 
-  // ZIP64 fallback — fflate's unzipSync handles the extended record.
-  if (totalEntries === 0xffff || cdSize === 0xffffffff || cdOffset === 0xffffffff) {
+  let summary: CdSummary;
+  try {
+    summary = readCdSummary(bytes, eocdOff);
+  } catch {
+    // Malformed EOCD / ZIP64 layout — fall back to fflate, which is more
+    // tolerant about archive quirks. The fallback still pre-checks declared
+    // entry sizes; see openViaUnzipSync.
     return openViaUnzipSync(bytes, resolvedLimits);
   }
 
   let entries: CdEntry[];
   try {
-    entries = parseCentralDirectory(bytes, cdOffset, totalEntries);
+    entries = parseCentralDirectory(bytes, summary.cdOffset, summary.totalEntries);
   } catch {
     // Malformed CD — fall back to fflate which is more tolerant.
     return openViaUnzipSync(bytes, resolvedLimits);
@@ -426,7 +544,14 @@ function inflateBounded(
   return out;
 }
 
-/** Fallback: hand the whole archive to fflate when ZIP64 / unsupported features turn up. */
+/**
+ * Fallback for archives we can't parse ourselves. The random-access reader
+ * now understands ZIP64 EOCD + the Zip64 Extended Information extra field, so
+ * the only way to reach this path is a malformed central directory. fflate's
+ * `unzipSync` is more forgiving but inflates every entry up front; for
+ * adversarial archives we still rely on a post-hoc cap check (the only one
+ * available without our own streaming decoder).
+ */
 function openViaUnzipSync(
   bytes: Uint8Array,
   limits: ReturnType<typeof resolveDecompressionLimits>,
@@ -440,8 +565,8 @@ function openViaUnzipSync(
   // fflate's `unzipSync` returns already-inflated bytes — we can't abort the
   // inflate mid-flight here, but a post-hoc check still rejects a malicious
   // archive *before* any caller-level code touches the bytes. The peak memory
-  // spike is bounded by what fflate just produced; in practice ZIP64-fallback
-  // archives are rare for xlsx, so this is acceptable.
+  // spike is bounded by what fflate just produced; the random-access path
+  // catches the common cases (ZIP64 + malformed-but-parseable CDs) up front.
   if (limits) {
     const budget = createBudget(limits);
     for (const [path, payload] of Object.entries(entries)) {

--- a/src/zip/writer.ts
+++ b/src/zip/writer.ts
@@ -58,6 +58,15 @@ export interface ZipWriter {
    * Idempotent; subsequent calls resolve to the same payload.
    */
   finalize(): Promise<Uint8Array>;
+
+  /**
+   * Release the sink and underlying writer without producing a valid archive.
+   * Use this from a surrounding catch block when serialization fails part-way
+   * through — without it, streaming sinks (`toFile` / `toWritable`) keep their
+   * file descriptors / writables open and the half-written xlsx looks valid on
+   * disk. Idempotent; safe to call after `finalize()`.
+   */
+  abort(cause?: unknown): void;
 }
 
 /** Writer handle for a single streaming entry. */
@@ -82,9 +91,6 @@ export interface StreamingEntryWriter {
  * without ever holding the full archive resident. Either kind plugs in here.
  */
 export function createZipWriter(sink: XlsxSink): ZipWriter {
-  if (!sink.toBytes) {
-    throw new OpenXmlIoError('createZipWriter: sink does not expose a chunked toBytes() writer');
-  }
   const writer = sink.toBytes();
   let finalised: Promise<Uint8Array> | undefined;
   let endCalled = false;
@@ -234,6 +240,18 @@ export function createZipWriter(sink: XlsxSink): ZipWriter {
         return writer.finish();
       })();
       return finalised;
+    },
+
+    abort(cause?: unknown): void {
+      if (finalised !== undefined) return;
+      // Mark finalised so any subsequent addEntry / finalize short-circuits.
+      finalised = Promise.resolve(new Uint8Array(0));
+      // Drop fflate's listener — we don't care about further `ondata` callbacks.
+      if (zipFinishResolve) {
+        zipFinishResolve();
+        zipFinishResolve = undefined;
+      }
+      writer.abort?.(cause);
     },
   };
 }

--- a/tests/cell/rich-text.test.ts
+++ b/tests/cell/rich-text.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { makeRichText, makeTextRun, richTextToString } from '../../src/cell/rich-text';
 import { makeColor } from '../../src/styles/colors';
+import { OpenXmlSchemaError } from '../../src/utils/exceptions';
 
 describe('makeTextRun', () => {
   it('builds a frozen run with text-only', () => {
@@ -18,7 +19,7 @@ describe('makeTextRun', () => {
 
   it('rejects non-string text', () => {
     // biome-ignore lint/suspicious/noExplicitAny: deliberate bad input
-    expect(() => makeTextRun(42 as any)).toThrowError(TypeError);
+    expect(() => makeTextRun(42 as any)).toThrowError(OpenXmlSchemaError);
   });
 });
 

--- a/tests/chartsheet/chartsheet.test.ts
+++ b/tests/chartsheet/chartsheet.test.ts
@@ -19,9 +19,9 @@ describe('Chartsheet XML round-trip', () => {
 
   it('preserves sheetPr properties (published / codeName / tabColor)', () => {
     const cs = makeChartsheet('Tinted');
-    cs.properties = { published: false, codeName: 'Sheet42', tabColorRgb: 'FF8800' };
+    cs.properties = { published: false, codeName: 'Sheet42', tabColor: { rgb: 'FF8800' } };
     const back = parseChartsheetXml(chartsheetToBytes(cs), 'Tinted');
-    expect(back.properties).toEqual({ published: false, codeName: 'Sheet42', tabColorRgb: 'FF8800' });
+    expect(back.properties).toEqual({ published: false, codeName: 'Sheet42', tabColor: { rgb: 'FF8800' } });
   });
 
   it('preserves sheetProtection (content + objects + algorithmName)', () => {

--- a/tests/utils/utf8.test.ts
+++ b/tests/utils/utf8.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { utf8ByteLength } from '../../src/utils/utf8';
+
+const encoder = new TextEncoder();
+const oracle = (s: string): number => encoder.encode(s).byteLength;
+
+describe('utf8ByteLength', () => {
+  it('matches TextEncoder for ASCII', () => {
+    const s = 'hello world';
+    expect(utf8ByteLength(s)).toBe(oracle(s));
+  });
+
+  it('matches TextEncoder for 2-byte codepoints', () => {
+    const s = 'café — naïve';
+    expect(utf8ByteLength(s)).toBe(oracle(s));
+  });
+
+  it('matches TextEncoder for 3-byte BMP codepoints (CJK)', () => {
+    const s = '日本語のテキスト ABC 中文';
+    expect(utf8ByteLength(s)).toBe(oracle(s));
+  });
+
+  it('matches TextEncoder for valid surrogate pairs (4-byte codepoints)', () => {
+    // U+1F600 (😀) — encoded as the surrogate pair D83D DE00 in UTF-16.
+    const s = '😀abc🚀';
+    expect(utf8ByteLength(s)).toBe(oracle(s));
+  });
+
+  it('handles a lone high surrogate at end of string like TextEncoder', () => {
+    const s = `abc${String.fromCharCode(0xd83d)}`;
+    expect(utf8ByteLength(s)).toBe(oracle(s));
+  });
+
+  it('handles a high surrogate followed by a non-low-surrogate without swallowing the next code unit', () => {
+    // High surrogate immediately followed by a BMP character. TextEncoder
+    // emits U+FFFD (3 bytes) for the unpaired surrogate, then the BMP
+    // character on its own. The previous implementation would swallow the
+    // 'X' entirely.
+    const s = `${String.fromCharCode(0xd83d)}X`;
+    expect(utf8ByteLength(s)).toBe(oracle(s));
+  });
+
+  it('handles a lone low surrogate', () => {
+    const s = `${String.fromCharCode(0xdc00)}Y`;
+    expect(utf8ByteLength(s)).toBe(oracle(s));
+  });
+
+  it('handles back-to-back high surrogates (each unpaired)', () => {
+    const s = `${String.fromCharCode(0xd83d)}${String.fromCharCode(0xd83d)}`;
+    expect(utf8ByteLength(s)).toBe(oracle(s));
+  });
+});

--- a/tests/workbook/iter-visible-worksheets.test.ts
+++ b/tests/workbook/iter-visible-worksheets.test.ts
@@ -52,6 +52,7 @@ describe('iterWorksheetsByState', () => {
   it('setSheetState updates the iter result', () => {
     const wb = createWorkbook();
     addWorksheet(wb, 'A');
+    addWorksheet(wb, 'B'); // keep one visible so hiding A is allowed
     expect([...iterWorksheetsByState(wb, 'hidden')]).toEqual([]);
     setSheetState(wb, 'A', 'hidden');
     expect([...iterWorksheetsByState(wb, 'hidden')].map((s) => s.title)).toEqual(['A']);

--- a/tests/workbook/sheet-state-bulk.test.ts
+++ b/tests/workbook/sheet-state-bulk.test.ts
@@ -26,6 +26,7 @@ describe('setSheetStates', () => {
   it('throws when a title is missing', () => {
     const wb = createWorkbook();
     addWorksheet(wb, 'A');
+    addWorksheet(wb, 'B'); // keep a visible companion so hiding A doesn't trip the last-visible guard
     expect(() => setSheetStates(wb, { A: 'hidden', Missing: 'hidden' })).toThrow(/no sheet named/);
   });
 });

--- a/tests/workbook/sheet-visibility.test.ts
+++ b/tests/workbook/sheet-visibility.test.ts
@@ -24,6 +24,7 @@ describe('sheet visibility helpers', () => {
   it('hideSheet / showSheet flip back and forth', () => {
     const wb = createWorkbook();
     addWorksheet(wb, 'A');
+    addWorksheet(wb, 'B'); // keep one visible so hiding A doesn't trigger the last-visible guard
     hideSheet(wb, 'A');
     expect(getSheetState(wb, 'A')).toBe('hidden');
     showSheet(wb, 'A');
@@ -33,6 +34,7 @@ describe('sheet visibility helpers', () => {
   it('veryHideSheet sets veryHidden state', () => {
     const wb = createWorkbook();
     addWorksheet(wb, 'A');
+    addWorksheet(wb, 'B'); // keep one visible
     veryHideSheet(wb, 'A');
     expect(getSheetState(wb, 'A')).toBe('veryHidden');
   });
@@ -40,6 +42,7 @@ describe('sheet visibility helpers', () => {
   it('setSheetState writes the requested state', () => {
     const wb = createWorkbook();
     addWorksheet(wb, 'A');
+    addWorksheet(wb, 'B'); // keep one visible
     setSheetState(wb, 'A', 'hidden');
     expect(getSheetState(wb, 'A')).toBe('hidden');
   });
@@ -47,9 +50,21 @@ describe('sheet visibility helpers', () => {
   it('throws on unknown sheet title', () => {
     const wb = createWorkbook();
     addWorksheet(wb, 'A');
+    addWorksheet(wb, 'B');
     expect(() => hideSheet(wb, 'Missing')).toThrow();
     expect(() => getSheetState(wb, 'Missing')).toThrow();
     expect(() => setSheetState(wb, 'Missing', 'hidden')).toThrow();
+  });
+
+  it('refuses to hide the last visible sheet', () => {
+    const wb = createWorkbook();
+    addWorksheet(wb, 'A');
+    addWorksheet(wb, 'B');
+    hideSheet(wb, 'B');
+    expect(() => hideSheet(wb, 'A')).toThrow(/last visible sheet/);
+    // Excel would refuse to open the workbook if both were hidden; the guard
+    // keeps the original state intact.
+    expect(getSheetState(wb, 'A')).toBe('visible');
   });
 
   it('round-trips state through save / load', async () => {

--- a/tests/xml/serializer.test.ts
+++ b/tests/xml/serializer.test.ts
@@ -35,9 +35,12 @@ describe('serializeXml — minimal cases', () => {
     expect(decode(serializeXml(el('t', {}, [], 'a & b < c > d')))).toContain('<t>a &amp; b &lt; c &gt; d</t>');
   });
 
-  it('escapes attribute values including newlines and tabs', () => {
+  it('escapes attribute values, leaving whitespace literal', () => {
+    // The canonical escapeXmlAttr keeps `\r` / `\n` / `\t` literal so the
+    // parser (which doesn't decode `&#9;` / `&#10;` / `&#13;`) round-trips
+    // them faithfully. See src/utils/escape.ts for the rationale.
     const node = el('a', { v: 'x"y\nz\tw' });
-    expect(decode(serializeXml(node))).toContain('<a v="x&quot;y&#10;z&#9;w"/>');
+    expect(decode(serializeXml(node))).toContain('<a v="x&quot;y\nz\tw"/>');
   });
 
   it('lets the caller suppress the XML declaration', () => {

--- a/tests/xml/stream-writer.test.ts
+++ b/tests/xml/stream-writer.test.ts
@@ -28,7 +28,9 @@ describe('createXmlStreamWriter — minimal output', () => {
     w.start('a', { v: 'x"y\nz' });
     w.text('a & b');
     w.end();
-    expect(decode(w.result())).toBe('<a v="x&quot;y&#10;z">a &amp; b</a>');
+    // Whitespace in attribute values stays literal — the parser doesn't
+    // decode `&#10;`, so escaping would break the round-trip.
+    expect(decode(w.result())).toBe('<a v="x&quot;y\nz">a &amp; b</a>');
   });
 
   it('omits standalone when requested', () => {

--- a/tests/zip/writer.test.ts
+++ b/tests/zip/writer.test.ts
@@ -85,8 +85,12 @@ describe('createZipWriter (basic)', () => {
   });
 
   it('rejects sinks without a buffered toBytes()', () => {
-    const stubSink = {} as Parameters<typeof createZipWriter>[0];
-    expect(() => createZipWriter(stubSink)).toThrowError(OpenXmlIoError);
+    // `XlsxSink.toBytes` is required by the type, so a sink without it can
+    // only be constructed via a cast. The runtime then surfaces the missing
+    // method as a TypeError on the first call.
+    // biome-ignore lint/suspicious/noExplicitAny: deliberate type-erasing cast
+    const stubSink = {} as any;
+    expect(() => createZipWriter(stubSink)).toThrow(TypeError);
   });
 });
 

--- a/tests/zip/zip64.test.ts
+++ b/tests/zip/zip64.test.ts
@@ -2,11 +2,13 @@
 // emits a plain ZIP32 EOCD; our writer post-processes the assembled
 // archive to splice in a ZIP64 EOCD record + locator when the entry
 // count exceeds 65535 and patches the EOCD entry-count fields with
-// the 0xFFFF sentinel. The reader detects the sentinel and falls back
-// to fflate's `unzipSync` for ZIP64-aware central-directory parsing.
+// the 0xFFFF sentinel. The reader parses the ZIP64 EOCD + Zip64
+// Extended Information extra field directly so the decompression-bomb
+// guards stay in effect on ZIP64 archives.
 
 import { describe, expect, it } from 'vitest';
 import { fromBuffer, toBuffer } from '../../src/io/node';
+import { OpenXmlIoError } from '../../src/utils/exceptions';
 import { openZip } from '../../src/zip/reader';
 import { createZipWriter } from '../../src/zip/writer';
 
@@ -59,11 +61,46 @@ describe('ZIP32 / ZIP64 entry-count limit', () => {
     expect((bytes[eocdOff + 8] ?? 0) | ((bytes[eocdOff + 9] ?? 0) << 8)).toBe(0xffff);
     expect((bytes[eocdOff + 10] ?? 0) | ((bytes[eocdOff + 11] ?? 0) << 8)).toBe(0xffff);
 
-    // Reader round-trip — falls back to fflate's unzipSync for ZIP64.
+    // Reader round-trip — the random-access reader parses ZIP64 natively.
     const archive = await openZip(fromBuffer(bytes));
     expect(archive.list().length).toBe(ENTRIES);
     expect(archive.read('f0.txt')).toEqual(payload);
     expect(archive.read(`f${ENTRIES - 1}.txt`)).toEqual(payload);
     archive.close();
   }, /* timeout */ 180_000);
+
+  it('fails closed when an archive declares ZIP64 but the ZIP64 EOCD record is missing', async () => {
+    // Build a valid small archive then patch the EOCD entry-count fields to
+    // 0xFFFF sentinels WITHOUT splicing in the matching ZIP64 EOCD record.
+    // The reader must refuse the file rather than fall back to unzipSync —
+    // a malformed ZIP64 archive shouldn't get the unbounded inflate
+    // treatment.
+    const sink = toBuffer();
+    const writer = createZipWriter(sink);
+    await writer.addEntry('a.txt', new TextEncoder().encode('hi'), { compress: false });
+    await writer.finalize();
+    const bytes = sink.result();
+
+    // Locate the EOCD and corrupt its entry-count fields.
+    let eocdOff = -1;
+    for (let p = bytes.length - 22; p >= 0; p--) {
+      if (
+        bytes[p] === 0x50 &&
+        bytes[p + 1] === 0x4b &&
+        bytes[p + 2] === 0x05 &&
+        bytes[p + 3] === 0x06
+      ) {
+        eocdOff = p;
+        break;
+      }
+    }
+    expect(eocdOff).toBeGreaterThan(0);
+    const patched = new Uint8Array(bytes);
+    patched[eocdOff + 8] = 0xff;
+    patched[eocdOff + 9] = 0xff;
+    patched[eocdOff + 10] = 0xff;
+    patched[eocdOff + 11] = 0xff;
+
+    await expect(openZip(fromBuffer(patched))).rejects.toBeInstanceOf(OpenXmlIoError);
+  });
 });


### PR DESCRIPTION
## Summary

8-commit follow-up to the v0.7.1 code-quality audit. Closes the High / Medium / Low items raised in that review, with one commit per theme.

| # | Commit | What it fixes |
|---|---|---|
| 1 | `fix(zip): harden ZIP64 read path against decompression bombs` | H-2 — parse ZIP64 EOCD + Zip64 Extended Information directly so the bomb caps fire on ZIP64 archives too, not after `unzipSync` materialised every entry. |
| 2 | `refactor(xml): unify attribute and text escapers in utils/escape.ts` | M-1 — drop 12 near-identical local escape regexes; `save.ts`'s missing `>` handling now matches the rest. |
| 3 | `fix(io): release streaming sinks on save failure, count UTF-8 accurately` | H-1, H-3, H-5, M-10, M-11 — `BufferedSinkWriter.abort()` so `toFile` / `toWritable` don't leave half-written `.xlsx`; accurate UTF-8 byte count in the streaming worksheet + stream writer; required `XlsxSink.toBytes`. |
| 4 | `fix(worksheet): plug three correctness holes in cell / sheet mutators` | H-4 (cross-sheet copy/move drops stale ids), M-7 (`setSheetState` refuses last visible sheet), M-9 (`makeTextRun` throws `OpenXmlSchemaError`). |
| 5 | `perf: drop quadratic / linear-scan patterns on four hot paths` | M-2, M-3, M-4, M-5 — `indexRelsById`, latin1 marker scan, head-pointer SAX queue, `Set`-indexed hyperlink rIds. |
| 6 | `refactor: single-pass describeWorkbook + hardened getRowValues` | M-6 (single-pass `describeWorkbook` via shared `classifyCellValue`), L-2 (`getRowValues` no longer hits V8's spread cap on dense rows), L-1 (`normalizePath` `..` comment). |
| 7 | `refactor(chartsheet)!: replace tabColorRgb with a typed Color tabColor` | **Breaking** — M-8 aligns Chartsheet tab colour with the worksheet `Color` model so consumers don't special-case sheet kinds and don't drop non-RGB attributes. |
| 8 | `chore(ci): tighten the CI gate and surface CLAUDE.md hard rules in lint` | M-12, M-13, M-14 — macOS / Windows test matrix with per-OS `libxml2`, dedicated `PERF_GATE=1` job, `typescript/no-explicit-any` on in `src/`. |

Changesets are added per-commit. The Chartsheet `tabColor` change is the only user-facing breaking one (pre-1.0 minor bump).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 2293 tests pass
- [x] `pnpm test:e2e` — 32 scenarios pass
- [x] `pnpm build`
- [x] `pnpm size` — within budgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)