### PR TITLE
site: tone the Svelte-orange accent into a softer ember

### DIFF
--- a/site/src/app.css
+++ b/site/src/app.css
@@ -23,11 +23,13 @@
   --fg-muted: #d4cdb8;
   --fg-faint: #a39b85;
 
-  /* Accents — Svelte orange recontextualized; brass as quiet co-accent. */
-  --accent: #ff3e00;
-  --accent-hot: #ff5a26;
-  --accent-soft: rgba(255, 62, 0, 0.13);
-  --accent-glow: rgba(255, 62, 0, 0.28);
+  /* Accents — ember (softened Svelte orange). Less neon at rest, still
+   * recognisably warm. Brass remains a quiet sibling co-accent shared
+   * with word-kit so the kit suite reads as one family. */
+  --accent: #e8501c;
+  --accent-hot: #ff6a36;
+  --accent-soft: rgba(232, 80, 28, 0.12);
+  --accent-glow: rgba(232, 80, 28, 0.22);
   --brass: #d4a544;
   --brass-soft: rgba(212, 165, 68, 0.12);
 


### PR DESCRIPTION
## Summary

- word-kit is shipping its sibling site, and the two need to read as one family. Pure Svelte orange (\`#ff3e00\`) at full saturation was the loudest note in the kit suite; tone it down to \`#e8501c\` (ember) so the type and hairline rules stay the headline.
- Brass (\`#d4a544\`) is unchanged — it's the shared sibling co-accent.
- Layout, fonts, and component grammar are untouched. This is a 1-variable + 1-comment change.

## Test plan

- [ ] \`pnpm --filter xlsx-kit-site dev\` — landing page hero / install strip / stats grid render the new accent
- [ ] Hover states on \`.btn.primary\` still pop (\`--accent-hot\` adjusted up to \`#ff6a36\`)
- [ ] Code-block coord tags and link colour read as the new tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)