### PR TITLE
fix(worksheet): preserve _xlfn. prefix on read so dynamic-array formulas round-trip

### DIFF
--- a/.changeset/preserve-xlfn-prefix-roundtrip.md
+++ b/.changeset/preserve-xlfn-prefix-roundtrip.md
@@ -1,0 +1,11 @@
+---
+'@office-kit/xlsx': patch
+---
+
+Preserve the `_xlfn.` future-function prefix on read so dynamic-array formulas
+survive a load → save round-trip. The reader stripped `_xlfn.` / `_xlfn._xlws.`
+into the model, and the writer emits formula text verbatim, so a loaded
+`_xlfn.SCAN(...)` was written back as bare `SCAN(...)` — an unknown name that
+Excel renders as `#NAME?`. Formula text is now kept verbatim (matching openpyxl),
+fixing every future function (SCAN, BYCOL, LAMBDA, XLOOKUP, FILTER, SEQUENCE,
+LET, ANCHORARRAY, …).

--- a/src/worksheet/reader.ts
+++ b/src/worksheet/reader.ts
@@ -1461,14 +1461,6 @@ const decodeCachedValue = (raw: string | undefined, t: string): number | string 
   }
 };
 
-// Strip the `_xlfn.` / `_xlfn._xlws.` prefixes Excel writes to disk for
-// future-functions on read. The writer side leaves formula text as-is, but
-// loaded files (typically from real Excel) ship the prefix and we surface a
-// clean bare-name formula to consumers.
-const FUTURE_FUNCTION_PREFIX_RE = /\b_xlfn\.(?:_xlws\.)?([A-Z][A-Z0-9.]*)/g;
-const stripFutureFunctionPrefix = (s: string): string =>
-  s.length > 0 && s.includes('_xlfn.') ? s.replace(FUTURE_FUNCTION_PREFIX_RE, '$1') : s;
-
 const handleFormula = (
   cell: Cell,
   fNode: XmlNode,
@@ -1477,7 +1469,13 @@ const handleFormula = (
   sharedFormulas: Map<number, SharedFormulaCache>,
 ): void => {
   const tAttr = fNode.attrs['t'] ?? 'normal';
-  const formula = stripFutureFunctionPrefix(fNode.text ?? '');
+  // Keep the formula text verbatim, including the `_xlfn.` / `_xlfn._xlws.`
+  // prefixes Excel writes for future-functions (SCAN, LAMBDA, XLOOKUP, …).
+  // The prefix is part of the stored grammar — a bare `SCAN(...)` is an
+  // unknown name that Excel renders as #NAME?. Stripping it here and then
+  // writing the model back verbatim corrupted every dynamic-array formula on
+  // a load → save round-trip. openpyxl surfaces the prefix verbatim too.
+  const formula = fNode.text ?? '';
   const opts = cached !== undefined ? { cachedValue: cached } : undefined;
   switch (tAttr as FormulaKind) {
     case 'normal':

--- a/src/worksheet/writer.ts
+++ b/src/worksheet/writer.ts
@@ -364,12 +364,16 @@ const serializeFormulaCell = (ref: string, styleAttr: string, f: FormulaValue): 
   if (f.del2) fAttrs.push('del2="1"');
   if (f.aca) fAttrs.push('aca="1"');
   if (f.ca) fAttrs.push('ca="1"');
-  // Pass the formula text through verbatim. Auto-prefixing future-functions
-  // with `_xlfn.` matches what Excel writes on save, but Excel itself only
-  // accepts that form in tandem with `cm="N"` cell metadata + an
-  // `xl/metadata.xml` part — otherwise it raises the "We found a problem"
-  // recovery dialog. Until we emit metadata, ship bare names: Excel 365 / 2021
-  // still resolves them; older Excel renders #NAME? but the workbook opens.
+  // Pass the formula text through verbatim, including any `_xlfn.` /
+  // `_xlfn._xlws.` future-function prefix the reader preserved. The prefix is
+  // part of the stored function name (`_xlfn.XLOOKUP`, `_xlfn.LET`, …) and
+  // Excel accepts it in an ordinary cell with no metadata — it is *not*
+  // coupled to `cm="N"` / `xl/metadata.xml`. That metadata coupling is a
+  // separate concern: it marks a spill as a *resizing* dynamic array, and we
+  // don't model it yet, so a round-tripped spill survives as a CSE array over
+  // its stored `ref` (values correct, no auto-resize) rather than a true
+  // dynamic array. We never synthesise a prefix here — we only echo what the
+  // source contained — so we can't emit a form Excel didn't itself author.
   const fAttrStr = fAttrs.length > 0 ? ` ${fAttrs.join(' ')}` : '';
   const formulaText = escapeXmlText(escapeCellString(f.formula));
   const fEl = formulaText.length > 0 ? `<f${fAttrStr}>${formulaText}</f>` : `<f${fAttrStr}/>`;

--- a/tests/e2e/scenarios/30-modern-formulas.test.ts
+++ b/tests/e2e/scenarios/30-modern-formulas.test.ts
@@ -1,19 +1,21 @@
 // Scenario 30: classic single-value formulas. Output: 30-modern-formulas.xlsx
 //
 // The original scenario covered Excel 365 / 2021 modern formulas (LET,
-// LAMBDA, FILTER, SORT, UNIQUE, SEQUENCE, XLOOKUP, BYROW). Two layers
-// of Excel constraints make those impractical to ship from this writer
-// without a full metadata implementation:
-//   1. Bare `LET(...)` / `XLOOKUP(...)` resolve only on Excel 365
-//      (LET) or Excel 2019+ (XLOOKUP); older Excel shows #NAME?.
-//   2. The `_xlfn.LET` / `_xlfn._xlws.FILTER` storage form Excel writes
-//      itself requires a paired `xl/metadata.xml` part + `cm="N"`
-//      cell-metadata reference — without those, Excel raises the
-//      "We found a problem" recovery dialog on open.
+// LAMBDA, FILTER, SORT, UNIQUE, SEQUENCE, XLOOKUP, BYROW). This scenario
+// deliberately stays on formulas that resolve in every Excel since 2007
+// (AVERAGE / VLOOKUP) for one reason only: version compatibility. Bare
+// `LET(...)` resolves only on Excel 365 and `XLOOKUP(...)` only on Excel
+// 2019+; older Excel shows #NAME?. AVERAGE / VLOOKUP keep the same
+// demonstrative shape (single-value arithmetic + lookup) and evaluate
+// everywhere.
 //
-// Until the metadata-emitter lands, fall back to formulas that exist in
-// every Excel since 2007: AVERAGE / VLOOKUP. Same demonstrative shape
-// (single-value arithmetic + lookup), guaranteed to evaluate everywhere.
+// Note: the `_xlfn.` / `_xlfn._xlws.` *name* prefix is not what blocks
+// this — that prefix is preserved verbatim on round-trip (see
+// `handleFormula` in src/worksheet/reader.ts) and Excel accepts it in an
+// ordinary cell with no metadata. The `cm="N"` + `xl/metadata.xml`
+// coupling is a *separate* concern that only marks a spill as a resizing
+// dynamic array; we don't emit that metadata yet, so a round-tripped
+// spill survives as a CSE array (values correct, no auto-resize).
 //
 // What to verify in Excel:
 // - E2 = AVERAGE(C2:C8) returns the average salary (84428.57).

--- a/tests/formula/future-function-roundtrip.test.ts
+++ b/tests/formula/future-function-roundtrip.test.ts
@@ -1,0 +1,62 @@
+// Regression: future-function (dynamic-array) formulas must keep their
+// `_xlfn.` storage prefix across a load → save round-trip.
+//
+// In OOXML, modern functions (SCAN, LAMBDA, XLOOKUP, FILTER, SEQUENCE, …)
+// are stored in `<f>` with an `_xlfn.` prefix — Excel strips it for display
+// and re-adds it on save. A stored bare `SCAN(...)` is an unknown name, so
+// Excel renders #NAME?. The reader used to strip `_xlfn.` into the model and
+// the writer emits formula text verbatim, so a loaded `_xlfn.SCAN` was
+// written back bare — corrupting every dynamic-array formula it merely passed
+// through. Consistent with openpyxl, which surfaces the prefix verbatim, the
+// reader now keeps the formula text as-is.
+
+import { describe, expect, it } from 'vitest';
+import { unzipSync, strFromU8 } from 'fflate';
+import { setArrayFormula } from '../../src/cell/cell';
+import { fromBuffer } from '../../src/io/node';
+import { loadWorkbook } from '../../src/io/load';
+import { workbookToBytes } from '../../src/io/save';
+import { addWorksheet, createWorkbook } from '../../src/workbook/workbook';
+import { setCell } from '../../src/worksheet/worksheet';
+
+const SCAN_FORMULA = '_xlfn.SCAN(0,B2:F2,_xlfn.LAMBDA(_xlpm.a,_xlpm.b,_xlpm.a+_xlpm.b))';
+
+const sheet1Xml = (bytes: Uint8Array): string => {
+  const part = unzipSync(bytes)['xl/worksheets/sheet1.xml'];
+  if (!part) throw new Error('xl/worksheets/sheet1.xml missing from output');
+  return strFromU8(part);
+};
+
+describe('future-function `_xlfn.` prefix round-trip', () => {
+  it('keeps `_xlfn.SCAN` / `_xlfn.LAMBDA` intact through load → save', async () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'Sheet1');
+    // A dynamic-array spill anchor, exactly as Excel stores it on disk.
+    const anchor = setCell(ws, 2, 8, null); // H2
+    setArrayFormula(anchor, 'H2:L2', SCAN_FORMULA, { cachedValue: 10 });
+
+    // First serialization ships the prefix verbatim (writer passes text through).
+    const bytes1 = await workbookToBytes(wb);
+    expect(sheet1Xml(bytes1)).toContain('_xlfn.SCAN');
+
+    // Load it back — this is where the read path used to strip the prefix.
+    const wb2 = await loadWorkbook(fromBuffer(bytes1));
+    const ref0 = wb2.sheets[0];
+    if (ref0?.kind !== 'worksheet') throw new Error('expected worksheet');
+    const cell = ref0.sheet.rows.get(2)?.get(8);
+    const value = cell?.value;
+    if (!value || typeof value !== 'object' || !('kind' in value) || value.kind !== 'formula') {
+      throw new Error('H2 is not a formula');
+    }
+    expect(value.formula).toContain('_xlfn.SCAN');
+    expect(value.formula).toContain('_xlfn.LAMBDA');
+
+    // Save again — the prefix must survive so Excel does not render #NAME?.
+    const bytes2 = await workbookToBytes(wb2);
+    const xml2 = sheet1Xml(bytes2);
+    expect(xml2).toContain('_xlfn.SCAN');
+    expect(xml2).toContain('_xlfn.LAMBDA');
+    // A bare `SCAN(` (no prefix) would be the corruption we are guarding against.
+    expect(xml2).not.toMatch(/(?<!\.)\bSCAN\(/);
+  });
+});

--- a/tests/formula/future-function-roundtrip.test.ts
+++ b/tests/formula/future-function-roundtrip.test.ts
@@ -59,4 +59,34 @@ describe('future-function `_xlfn.` prefix round-trip', () => {
     // A bare `SCAN(` (no prefix) would be the corruption we are guarding against.
     expect(xml2).not.toMatch(/(?<!\.)\bSCAN\(/);
   });
+
+  // The `_xlfn._xlws.` compound prefix is the worksheet-function form Excel
+  // writes for the spilling dynamic-array functions (FILTER, SORT, UNIQUE,
+  // …). Stripping only the leading `_xlfn.` would leave a bare `_xlws.FILTER`,
+  // and stripping both would leave bare `FILTER` — both #NAME? on reopen. The
+  // whole prefix must survive verbatim.
+  it('keeps the compound `_xlfn._xlws.` prefix (FILTER/SORT) intact', async () => {
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, 'Sheet1');
+    const formula = '_xlfn._xlws.SORT(_xlfn._xlws.FILTER(A2:A8,B2:B8>0))';
+    const anchor = setCell(ws, 2, 8, null); // H2
+    setArrayFormula(anchor, 'H2:H8', formula, { cachedValue: 1 });
+
+    const bytes1 = await workbookToBytes(wb);
+    const wb2 = await loadWorkbook(fromBuffer(bytes1));
+    const ref0 = wb2.sheets[0];
+    if (ref0?.kind !== 'worksheet') throw new Error('expected worksheet');
+    const value = ref0.sheet.rows.get(2)?.get(8)?.value;
+    if (!value || typeof value !== 'object' || !('kind' in value) || value.kind !== 'formula') {
+      throw new Error('H2 is not a formula');
+    }
+    // Model preserves the full compound prefix, not a partially-stripped form.
+    expect(value.formula).toBe(formula);
+
+    const xml2 = sheet1Xml(await workbookToBytes(wb2));
+    expect(xml2).toContain('_xlfn._xlws.FILTER');
+    expect(xml2).toContain('_xlfn._xlws.SORT');
+    // No partially- or fully-stripped name may leak through.
+    expect(xml2).not.toMatch(/(?<!\.)\b(?:FILTER|SORT)\(/);
+  });
 });


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Future-function (dynamic-array) formulas are corrupted on a load → save round-trip. A workbook loaded with `_xlfn.SCAN(...)` is written back as bare `SCAN(...)`, which Excel renders as `#NAME?`. This preserves the `_xlfn.` prefix verbatim on read (matching openpyxl), so every modern function survives round-tripping intact.

## Motivation

In OOXML, modern functions are stored in `<f>` with an `_xlfn.` (or `_xlfn._xlws.`) prefix — Excel strips it for display and re-adds it on save. A stored bare `SCAN(...)` is an unknown name, so Excel shows `#NAME?`.

The reader stripped the prefix into the in-memory model (`stripFutureFunctionPrefix` in `src/worksheet/reader.ts`), while the writer emits formula text verbatim (`serializeFormulaCell` in `src/worksheet/writer.ts`). So a loaded `_xlfn.SCAN(...)` became bare `SCAN(...)` on the way out — corrupting **every** dynamic-array / future function (`SCAN`, `BYCOL`, `LAMBDA`, `XLOOKUP`, `FILTER`, `SEQUENCE`, `LET`, `ANCHORARRAY`, …), including cells the caller never touched (e.g. loading a workbook, editing one input, saving).

Minimal repro:

```ts
const wb = createWorkbook();
const ws = addWorksheet(wb, 'Sheet1');
setArrayFormula(setCell(ws, 2, 8, null), 'H2:L2',
  '_xlfn.SCAN(0,B2:F2,_xlfn.LAMBDA(_xlpm.a,_xlpm.b,_xlpm.a+_xlpm.b))', { cachedValue: 10 });

const bytes1 = await workbookToBytes(wb);           // sheet1.xml contains _xlfn.SCAN ✅
const wb2    = await loadWorkbook(fromBuffer(bytes1)); // model formula is now bare SCAN(...) ❌
const bytes2 = await workbookToBytes(wb2);           // sheet1.xml now contains bare SCAN(...) → #NAME?
```

A note on the earlier decision to ship bare names (commit 2cfc97d / scenario 30): the concern was that the `_xlfn.` storage form needs a paired `cm=` + `xl/metadata.xml` or Excel raises the recovery dialog. That coupling applies to the **dynamic-array cell metadata** (the `cm` attribute that marks a spill as a *resizing* array), not to the `_xlfn.` name prefix itself — Excel writes `_xlfn.XLOOKUP` in ordinary cells with no metadata at all. This PR does not synthesise any new `_xlfn.` form: it only preserves what the source file already contained, so it cannot produce a form Excel did not itself author.

Closes #<!-- no existing issue -->

## Changes

- `src/worksheet/reader.ts`: keep `<f>` formula text verbatim on read instead of stripping the `_xlfn.` / `_xlfn._xlws.` prefix. Removes the now-unused `stripFutureFunctionPrefix` helper and its regex.
- Behavior change: `cell.value.formula` for a future function now reads `_xlfn.SCAN(...)` (as stored, and as openpyxl surfaces it) rather than bare `SCAN(...)`.

## Testing

- New regression test `tests/formula/future-function-roundtrip.test.ts` builds a `_xlfn.SCAN` / `_xlfn.LAMBDA` spill anchor, round-trips it through `workbookToBytes` → `loadWorkbook` → `workbookToBytes`, and asserts the serialized `sheet1.xml` still contains the prefix (and no bare `SCAN(`). It fails on `main` (model formula comes back as `SCAN(0,B2:F2,LAMBDA(...))`) and passes with this change.
- `pnpm test` — full unit/property/round-trip suite green (the only failures in my environment are the 4 `tests/conformance/*` files that shell out to `xmllint`, which isn't installed locally; they are unrelated to this change).
- `pnpm test:e2e`, `pnpm typecheck`, `pnpm lint`, `pnpm build` all pass.

Reproduce:

```sh
pnpm test tests/formula/future-function-roundtrip.test.ts
```

## Breaking changes

None for file output. Minor observable change to the in-memory API: consumers that read `cell.value.formula` for a future function now see the `_xlfn.`-prefixed form (previously stripped). This matches how the formula is stored on disk and how openpyxl surfaces it. A changeset is included (`patch`).

## Related (out of scope, happy to follow up)

Separately, the reader/writer has no cell-metadata model, so the `cm` attribute that marks a spill as a *true resizing* dynamic array is dropped on round-trip. Values stay correct (the formula survives as a CSE array over its stored `ref`), but the array won't auto-resize. That's a larger change (needs an `xl/metadata.xml` model) — I've kept this PR scoped to the `_xlfn.` fix and can open a separate issue/PR for the metadata if useful.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a user-visible change, I have run `pnpm changeset` and committed the result.
- [x] If this is a breaking change, I have flagged it above and the changeset is marked accordingly.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
