### PR TITLE
fix: accept border style="none" in loadWorkbook (#99)

### DIFF
--- a/.changeset/fix-border-style-none.md
+++ b/.changeset/fix-border-style-none.md
@@ -1,0 +1,11 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: `loadWorkbook` rejected borders with `style="none"` (#99)
+
+Files written by OnlyOffice (and any producer that emits the explicit no-border
+value) set border sides to `style="none"`, which is the first value of
+ECMA-376's `ST_BorderStyle` enumeration. Loading such a file failed with
+`expected one of [thin, medium, ...]; got "none"`. `none` is now accepted and
+round-trips faithfully; it draws no stroke in HTML/SVG preview.

--- a/src/styles/borders.ts
+++ b/src/styles/borders.ts
@@ -9,6 +9,10 @@ import { OpenXmlSchemaError } from '../utils/exceptions';
 import { type Color, colorToHex, makeColor } from './colors';
 
 export type SideStyle =
+  // ECMA-376 §18.18.3 ST_BorderStyle lists `none` (no stroke) as a first-class
+  // value; Excel omits the side element for it, but OnlyOffice writes it out
+  // explicitly, so we must accept and round-trip it (issue #99).
+  | 'none'
   | 'thin'
   | 'medium'
   | 'thick'
@@ -24,6 +28,7 @@ export type SideStyle =
   | 'slantDashDot';
 
 export const SIDE_STYLES: ReadonlyArray<SideStyle> = Object.freeze([
+  'none',
   'thin',
   'medium',
   'thick',

--- a/tests/styles/issue-99.test.ts
+++ b/tests/styles/issue-99.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { fromTree } from '../../src/schema/serialize';
+import { makeSide } from '../../src/styles/borders';
+import { SideSchema } from '../../src/styles/borders.schema';
+import { parseXml } from '../../src/xml/parser';
+import { SHEET_MAIN_NS } from '../../src/xml/namespaces';
+
+// https://github.com/office-kit/xlsx/issues/99
+// OnlyOffice writes explicit `<left style="none"/>` sides. `none` is the first
+// value of ECMA-376 §18.18.3 ST_BorderStyle, so it must parse, not throw
+// "expected one of [...]; got \"none\"".
+describe('issue #99: border style "none"', () => {
+  it('parses a side with style="none" from XML', () => {
+    const xml = `<side xmlns="${SHEET_MAIN_NS}" style="none"/>`;
+    const side = fromTree(parseXml(xml), SideSchema);
+    expect(side.style).toBe('none');
+  });
+
+  it('makeSide accepts style="none"', () => {
+    expect(makeSide({ style: 'none' }).style).toBe('none');
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`loadWorkbook` rejected any workbook whose border sides use `style="none"`, throwing `expected one of [thin, medium, ...]; got "none"`. `none` is the first value of ECMA-376 §18.18.3 `ST_BorderStyle` (no stroke), so it is valid input and is now accepted.

## Motivation

OnlyOffice — and other producers — write the no-border value explicitly as `<left style="none"/>`. Excel omits the side element in that case, which is why this went unnoticed until a file from OnlyOffice hit it. The value was simply missing from the `SideStyle` enumeration.

Closes #99

## Changes

- `@office-kit/xlsx/styles`: `SideStyle` (and `SIDE_STYLES`) now include `'none'`. Sides with `style="none"` parse, round-trip faithfully, and draw no stroke in HTML/SVG preview.

## Testing

- Added `tests/styles/issue-99.test.ts` — a failing-first test that parses `<side style="none"/>` and exercises `makeSide({ style: 'none' })`.
- Verified end-to-end against the reporter's attached `lookup_values_lut.xlsx` (5 sides with `style="none"`): it threw before this change and loads cleanly after, with `none` preserved on round-trip.
- `pnpm typecheck && pnpm lint && pnpm test` green.

Reproduce:

```sh
pnpm vitest run tests/styles/issue-99.test.ts
```

## Breaking changes

None. This widens accepted input; existing values are unaffected.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->