### PR TITLE
fix: header/footer picture (legacyDrawingHF) lost its relationship on round-trip (#104)

### DIFF
--- a/.changeset/header-footer-vml-rels.md
+++ b/.changeset/header-footer-vml-rels.md
@@ -1,0 +1,7 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: round-tripping a sheet with a header/footer picture (`<legacyDrawingHF>`) produced a file Excel refused to open (#104)
+
+`loadWorkbook` → `saveWorkbook` re-emitted `<legacyDrawingHF r:id="…"/>` but dropped the `vmlDrawing` relationship it points at, the VML part's own `.rels`, and the image behind it, and the surviving `.vml` part had no content type. Parts referenced by relationships the writer re-emits verbatim are now carried over together with their own relationships (transitively), and `<Default>` content types from the source manifest are preserved for such parts.

--- a/src/io/load.ts
+++ b/src/io/load.ts
@@ -21,7 +21,7 @@ import { corePropsFromBytes } from '../packaging/core';
 import { customPropsFromBytes } from '../packaging/custom';
 import { extendedPropsFromBytes } from '../packaging/extended';
 import { manifestFromBytes } from '../packaging/manifest';
-import { findById, indexRelsById, relsFromBytes } from '../packaging/relationships';
+import { findById, indexRelsById, type Relationship, relsFromBytes } from '../packaging/relationships';
 import { parseStylesheetXml } from '../styles/stylesheet-reader';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import type { DefinedName } from '../workbook/defined-names';
@@ -30,6 +30,7 @@ import { parseSharedStringsXml, type SharedStringsTable } from '../workbook/shar
 import { createWorkbook, type SheetRef, type SheetState, type Workbook } from '../workbook/workbook';
 import { parseCommentsXml } from '../worksheet/comments-xml';
 import { parseWorksheetXml } from '../worksheet/reader';
+import type { Worksheet } from '../worksheet/worksheet';
 import { parseTableXml } from '../worksheet/table-xml';
 import {
   ARC_APP,
@@ -340,6 +341,7 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
   if (themeXml) wb.themeXml = themeXml;
   if (definedNamesFromXml.length > 0) wb.definedNames = definedNamesFromXml;
   const seenTitles = new Set<string>();
+  const passthroughRoots: string[] = [];
   for (const entry of sheetEntries) {
     if (seenTitles.has(entry.name)) {
       throw new OpenXmlSchemaError(`loadWorkbook: duplicate sheet name "${entry.name}"`);
@@ -482,8 +484,15 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
       ...(loadDrawing ? { loadDrawing } : {}),
     });
     if (sheetRels) {
-      const extras = captureSheetRelsExtras(sheetRels);
-      if (extras.length > 0) ws.relsExtras = extras;
+      const extras = captureSheetRelsExtras(sheetRels, ws);
+      if (extras.length > 0) {
+        ws.relsExtras = extras;
+        // The writer re-emits these rels verbatim, so whatever they point at
+        // has to be carried over as passthrough or the output dangles.
+        for (const e of extras) {
+          if (e.targetMode !== 'External') passthroughRoots.push(resolveRelTarget(sheetPath, e.target));
+        }
+      }
     }
     const ref: SheetRef = {
       kind: 'worksheet',
@@ -500,7 +509,7 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
 
   // Pass-through: capture parts we don't model (VBA / pivot / activeX / OLE /
   // customUI / customXml / etc.) so re-saving doesn't drop them.
-  capturePassthrough(archive, manifest, wb);
+  capturePassthrough(archive, manifest, wb, passthroughRoots);
   return wb;
 }
 
@@ -518,14 +527,19 @@ const SHEET_MODELED_REL_TYPES: ReadonlySet<string> = new Set([
  * captured passthrough parts (pivotTable / queryTable / slicer /
  * printerSettings / oleObject / customProperty / threadedComment) remain
  * reachable from the worksheet after a round-trip.
+ *
+ * `vmlDrawing` is a modeled type only for the comments VML (regenerated from
+ * `ws.legacyComments`). The header/footer VML behind `<legacyDrawingHF>` is
+ * re-emitted by its original r:id, so that one rel rides along as an extra.
  */
 function captureSheetRelsExtras(
   sheetRels: import('../packaging/relationships').Relationships,
-): Array<{ id: string; type: string; target: string }> {
-  const extras: Array<{ id: string; type: string; target: string }> = [];
+  ws: Worksheet,
+): Relationship[] {
+  const extras: Relationship[] = [];
   for (const rel of sheetRels.rels) {
-    if (SHEET_MODELED_REL_TYPES.has(rel.type)) continue;
-    extras.push({ id: rel.id, type: rel.type, target: rel.target });
+    if (SHEET_MODELED_REL_TYPES.has(rel.type) && rel.id !== ws.legacyDrawingHFRId) continue;
+    extras.push(rel);
   }
   return extras;
 }
@@ -1140,17 +1154,49 @@ const isPassthroughPath = (path: string, bytes?: Uint8Array): boolean => {
  * Walk the archive after the modeled parts are loaded and capture any remaining
  * content into `wb.passthrough`. The dedicated VBA project binaries land on
  * their own slots so the writer can promote the workbook content type to xlsm.
+ *
+ * `roots` are parts the worksheet writer will reference by their original
+ * r:id (see `captureSheetRelsExtras`). Each root is captured together with
+ * its own `.rels` file and, transitively, every internal target of those rels
+ * — that is what keeps a header/footer VML's image (`vmlDrawingN.vml.rels` →
+ * `xl/media/imageN.jpeg`) attached. Passthrough VML parts get the same
+ * treatment because form-control VML references images the same way.
  */
 function capturePassthrough(
   archive: ZipArchive,
   manifest: import('../packaging/manifest').Manifest,
   wb: Workbook,
+  roots: ReadonlyArray<string>,
 ): void {
   const overrides = new Map<string, string>();
   for (const o of manifest.overrides) {
     // Manifest paths are package-absolute (`/xl/...`); strip the leading slash.
     overrides.set(o.partName.replace(/^\//, ''), o.contentType);
   }
+  const defaults = new Map<string, string>();
+  for (const d of manifest.defaults) defaults.set(d.ext.toLowerCase(), d.contentType);
+
+  const capture = (path: string, bytes: Uint8Array): void => {
+    if (!wb.passthrough) wb.passthrough = new Map();
+    wb.passthrough.set(path, bytes);
+    const ct = overrides.get(path);
+    if (ct !== undefined) {
+      if (!wb.passthroughContentTypes) wb.passthroughContentTypes = new Map();
+      wb.passthroughContentTypes.set(path, ct);
+      return;
+    }
+    // No Override → the part is typed by its extension's Default. Remember it
+    // so the writer can re-emit that Default; it only knows the extensions of
+    // parts it produces itself.
+    const ext = path.slice(path.lastIndexOf('.') + 1).toLowerCase();
+    const dct = defaults.get(ext);
+    if (dct !== undefined) {
+      if (!wb.passthroughDefaults) wb.passthroughDefaults = new Map();
+      wb.passthroughDefaults.set(ext, dct);
+    }
+  };
+
+  const closureRoots: string[] = [...roots];
   for (const path of archive.list()) {
     if (path === 'xl/vbaProject.bin') {
       wb.vbaProject = archive.read(path);
@@ -1166,12 +1212,26 @@ function capturePassthrough(
     let cached: Uint8Array | undefined;
     if (isVmlDrawing(path)) cached = archive.read(path);
     if (!isPassthroughPath(path, cached)) continue;
-    if (!wb.passthrough) wb.passthrough = new Map();
-    wb.passthrough.set(path, cached ?? archive.read(path));
-    const ct = overrides.get(path);
-    if (ct !== undefined) {
-      if (!wb.passthroughContentTypes) wb.passthroughContentTypes = new Map();
-      wb.passthroughContentTypes.set(path, ct);
+    capture(path, cached ?? archive.read(path));
+    if (cached !== undefined) closureRoots.push(path);
+  }
+
+  // Breadth-first over rels so a chain like sheet → VML → image is captured
+  // whole. `visited` (not `wb.passthrough`) gates the walk because roots
+  // captured by the prefix scan above still need their rels followed.
+  const visited = new Set<string>();
+  // for…of re-reads the array length each step, so targets pushed mid-walk
+  // are visited too.
+  for (const path of closureRoots) {
+    if (visited.has(path) || !archive.has(path)) continue;
+    visited.add(path);
+    if (!wb.passthrough?.has(path)) capture(path, archive.read(path));
+    const relsPath = relsPathFor(path);
+    if (!archive.has(relsPath)) continue;
+    const relsBytes = archive.read(relsPath);
+    capture(relsPath, relsBytes);
+    for (const r of relsFromBytes(relsBytes).rels) {
+      if (r.targetMode !== 'External') closureRoots.push(resolveRelTarget(path, r.target));
     }
   }
 }

--- a/src/io/save.ts
+++ b/src/io/save.ts
@@ -220,7 +220,10 @@ async function saveWorkbookImpl(wb: Workbook, writer: ReturnType<typeof createZi
     vmlBytes: Uint8Array;
   }
   const commentEmits: CommentEmit[] = [];
-  let nextCommentsId = 1;
+  // Passthrough carries form-control / header-footer VML under the same
+  // xl/drawings/vmlDrawingN.vml naming, so start past whatever is already
+  // taken — the zip writer rejects duplicate entries.
+  let nextCommentsId = nextFreeIndex(wb, /^xl\/drawings\/vmlDrawing(\d+)\.vml$/);
   // Drawings: workbook-global drawingN counter for xl/drawings/drawingN.xml +
   // matching drawing-rels file (when chart items are present).
   interface DrawingEmit {
@@ -255,7 +258,9 @@ async function saveWorkbookImpl(wb: Workbook, writer: ReturnType<typeof createZi
   }
   const imageEmits: ImageEmit[] = [];
   const imageExts = new Set<string>();
-  let nextImageId = 1;
+  // Same collision guard as for VML: images referenced by passthrough parts
+  // keep their original xl/media/imageN.* names.
+  let nextImageId = nextFreeIndex(wb, /^xl\/media\/image(\d+)\./);
   // Track separate counters so worksheet / chartsheet IDs do not collide (Excel
   // uses xl/worksheets/sheetN.xml and xl/chartsheets/sheetM.xml independently
   // of one another).
@@ -649,6 +654,12 @@ async function saveWorkbookImpl(wb: Workbook, writer: ReturnType<typeof createZi
   const manifest = makeManifest();
   addDefault(manifest, 'rels', 'application/vnd.openxmlformats-package.relationships+xml');
   addDefault(manifest, 'xml', 'application/xml');
+  // Defaults carried over for passthrough parts go first: addDefault is
+  // last-wins, so the writer's own registrations below (vml for comments, bin
+  // for VBA, image formats) still take precedence on a shared extension.
+  if (wb.passthroughDefaults) {
+    for (const [ext, ct] of wb.passthroughDefaults) addDefault(manifest, ext, ct);
+  }
   // VBA-bearing workbooks promote the workbook content type to xlsm.
   const workbookContentType = wb.vbaProject
     ? 'application/vnd.ms-excel.sheet.macroEnabled.main+xml'
@@ -704,6 +715,22 @@ async function saveWorkbookImpl(wb: Workbook, writer: ReturnType<typeof createZi
 
   // ---- 8. close ----------------------------------------------------------
   await writer.finalize();
+}
+
+/**
+ * 1 + the highest N among passthrough paths matching `pattern` (whose first
+ * capture group is N), so freshly numbered modeled parts never collide with a
+ * carried-over one.
+ */
+function nextFreeIndex(wb: Workbook, pattern: RegExp): number {
+  let max = 0;
+  if (wb.passthrough) {
+    for (const path of wb.passthrough.keys()) {
+      const m = pattern.exec(path);
+      if (m?.[1] !== undefined) max = Math.max(max, Number.parseInt(m[1], 10));
+    }
+  }
+  return max + 1;
 }
 
 /** Serialise the minimum `<workbook><sheets/></workbook>` Excel needs to load a sheet list. */

--- a/src/workbook/workbook.ts
+++ b/src/workbook/workbook.ts
@@ -99,6 +99,13 @@ export interface Workbook {
    */
   passthroughContentTypes?: Map<string, string>;
   /**
+   * Default content type per extension for pass-through parts that had no
+   * Override in the source manifest (`vml`, `jpeg`, `bin` …). The writer only
+   * knows the extensions of parts it produces itself, so these are re-emitted
+   * as `<Default>` entries to keep carried-over parts typed.
+   */
+  passthroughDefaults?: Map<string, string>;
+  /**
    * Top-level `<workbook>` children that aren't `<sheets>` or `<definedNames>`
    * (e.g. `<fileVersion>`, `<workbookPr>`, `<bookViews>`, `<calcPr>`,
    * `<pivotCaches>`, `<extLst>`). Captured verbatim so re-saving keeps

--- a/tests/io/issue-104.test.ts
+++ b/tests/io/issue-104.test.ts
@@ -1,0 +1,141 @@
+// Regression for https://github.com/office-kit/xlsx/issues/104 — a sheet with a
+// header/footer picture (`<legacyDrawingHF r:id>` → VML → image) must survive
+// load → save with every relationship still resolvable. Before the fix the
+// writer re-emitted the r:id but dropped the sheet rel, the VML's own rels and
+// the image, and Excel refused the output as corrupt.
+
+import { zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { fromBuffer } from '../../src/io/node';
+import { loadWorkbook } from '../../src/io/load';
+import { workbookToBytes } from '../../src/io/save';
+import { openZip } from '../../src/zip/reader';
+import { validateXlsx } from '../conformance/validate';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+// Minimal package modelled on the reporter's fixture: one empty sheet whose
+// header is `&G` (picture placeholder), backed by a VML drawing that carries
+// no comment shapes and references one JPEG. The VML is deliberately numbered
+// 2 so a comments writer starting at vmlDrawing1 would not mask a dropped part.
+const IMAGE_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00]);
+
+const buildFixture = (): Uint8Array =>
+  zipSync({
+    '[Content_Types].xml': enc.encode(
+      `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        '<Default Extension="jpeg" ContentType="image/jpeg"/>' +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="xml" ContentType="application/xml"/>' +
+        '<Default Extension="vml" ContentType="application/vnd.openxmlformats-officedocument.vmlDrawing"/>' +
+        '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+        '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+        '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' +
+        '</Types>',
+    ),
+    '_rels/.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/officeDocument" Target="xl/workbook.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/workbook.xml': enc.encode(
+      `${XML_DECL}<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="${REL_NS}">` +
+        '<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>',
+    ),
+    'xl/_rels/workbook.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/worksheet" Target="worksheets/sheet1.xml"/>` +
+        `<Relationship Id="rId2" Type="${REL_NS}/styles" Target="styles.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/styles.xml': enc.encode(
+      `${XML_DECL}<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">` +
+        '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+        '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
+        '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+        '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+        '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>' +
+        '</styleSheet>',
+    ),
+    'xl/worksheets/sheet1.xml': enc.encode(
+      `${XML_DECL}<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="${REL_NS}">` +
+        '<sheetData/>' +
+        '<headerFooter><oddHeader>&amp;L&amp;G</oddHeader></headerFooter>' +
+        '<legacyDrawingHF r:id="rId4"/>' +
+        '</worksheet>',
+    ),
+    'xl/worksheets/_rels/sheet1.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId4" Type="${REL_NS}/vmlDrawing" Target="../drawings/vmlDrawing2.vml"/>` +
+        '</Relationships>',
+    ),
+    'xl/drawings/vmlDrawing2.vml': enc.encode(
+      '<xml xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel">' +
+        '<o:shapelayout v:ext="edit"><o:idmap v:ext="edit" data="1"/></o:shapelayout>' +
+        '<v:shapetype id="_x0000_t75" coordsize="21600,21600" o:spt="75" o:preferrelative="t" path="m@4@5l@4@11@9@11@9@5xe" filled="f" stroked="f">' +
+        '<v:stroke joinstyle="miter"/><v:path o:extrusionok="f" gradientshapeok="t" o:connecttype="rect"/></v:shapetype>' +
+        '<v:shape id="LH" o:spid="_x0000_s1025" type="#_x0000_t75" style="position:absolute;margin-left:0;margin-top:0;width:100pt;height:40pt;z-index:1">' +
+        '<v:imagedata o:relid="rId1" o:title="letterhead"/><o:lock v:ext="edit" rotation="t"/></v:shape>' +
+        '</xml>',
+    ),
+    'xl/drawings/_rels/vmlDrawing2.vml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/image" Target="../media/image1.jpeg"/>` +
+        '</Relationships>',
+    ),
+    'xl/media/image1.jpeg': IMAGE_BYTES,
+  });
+
+const roundTrip = async (): Promise<Uint8Array> =>
+  workbookToBytes(await loadWorkbook(fromBuffer(buildFixture())));
+
+describe('issue #104 — header/footer VML picture survives a round-trip', () => {
+  it('re-emits <legacyDrawingHF> together with a resolvable vmlDrawing rel', async () => {
+    const bytes = await roundTrip();
+    const archive = await openZip(fromBuffer(bytes));
+    try {
+      const sheetXml = dec.decode(archive.read('xl/worksheets/sheet1.xml'));
+      const hfRId = /<legacyDrawingHF r:id="([^"]+)"\/>/.exec(sheetXml)?.[1];
+      expect(hfRId).toBeDefined();
+
+      expect(archive.has('xl/worksheets/_rels/sheet1.xml.rels')).toBe(true);
+      const sheetRels = dec.decode(archive.read('xl/worksheets/_rels/sheet1.xml.rels'));
+      expect(sheetRels).toMatch(
+        new RegExp(
+          `<Relationship[^>]*Id="${hfRId}"[^>]*Type="${REL_NS}/vmlDrawing"[^>]*Target="../drawings/vmlDrawing2.vml"`,
+        ),
+      );
+    } finally {
+      archive.close();
+    }
+  });
+
+  it('carries the VML part, its rels and the referenced image', async () => {
+    const bytes = await roundTrip();
+    const archive = await openZip(fromBuffer(bytes));
+    try {
+      expect(archive.has('xl/drawings/vmlDrawing2.vml')).toBe(true);
+      expect(archive.has('xl/drawings/_rels/vmlDrawing2.vml.rels')).toBe(true);
+      expect(archive.read('xl/media/image1.jpeg')).toEqual(IMAGE_BYTES);
+    } finally {
+      archive.close();
+    }
+  });
+
+  it('produces a package where every part has a content type and every rel resolves', async () => {
+    const result = await validateXlsx(await roundTrip(), { skipXsd: true });
+    expect(result.issues).toEqual([]);
+  });
+
+  it('is stable across a second round-trip', async () => {
+    const once = await roundTrip();
+    const twice = await workbookToBytes(await loadWorkbook(fromBuffer(once)));
+    const result = await validateXlsx(twice, { skipXsd: true });
+    expect(result.issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Round-tripping a workbook whose sheet has a header/footer picture (`<legacyDrawingHF r:id="…"/>`) wrote `sheet1.xml` with the `r:id` intact but no relationship behind it, no `vmlDrawingN.vml.rels`, no `xl/media/imageN.jpeg`, and a `.vml` part with no content type — Excel refused the output as corrupt. The loader now carries every part behind a relationship the writer re-emits verbatim, including that part's own rels and their targets, and preserves the source manifest's `<Default>` content types for them.

## Motivation

Reported in #104 with a minimal fixture. The issue was auto-closed by template-compliance (missing template anchor), but the report is accurate and reproducible: the reporter's fixture round-trips to a package with a dangling `rId4`.

Root cause: `vmlDrawing` is in `SHEET_MODELED_REL_TYPES` because the *comments* VML is regenerated from `Worksheet.legacyComments`. That blanket exclusion also dropped the header/footer VML rel, even though the writer re-emits `legacyDrawingHFRId` unchanged. Separately, passthrough capture was prefix-based (`xl/pivotTables/`, `xl/activeX/`, …) and never followed a part's `.rels`, so `xl/drawings/_rels/vmlDrawing2.vml.rels` and `xl/media/image1.jpeg` were left behind; and `passthroughContentTypes` only recorded `<Override>` entries, so the `.vml` lost its `<Default>`-derived type.

Closes #104

## Changes

- `loadWorkbook`: the `vmlDrawing` rel referenced by `<legacyDrawingHF>` is kept in `Worksheet.relsExtras`, so the writer emits it alongside the element.
- `loadWorkbook`: every internal target of a `relsExtras` entry, and every passthrough VML, is captured together with its own `.rels` and (transitively) those rels' targets. This is the general invariant behind the fix — "whatever the writer references by its original rId must exist in the output" — and it also closes the same gap for `<picture>` background images and `customProperty` parts, which were dangling for the same reason.
- New optional `Workbook.passthroughDefaults` (`Map<ext, contentType>`): `<Default>` content types from the source manifest for passthrough parts that had no `<Override>`. `saveWorkbook` re-emits them before its own `addDefault` calls, so the writer's registrations still win on a shared extension (`vml` for comments, `bin` for VBA).
- `saveWorkbook`: `xl/drawings/vmlDrawingN.vml` and `xl/media/imageN.*` counters now start past any carried-over passthrough name, so freshly generated comment VML / drawing images cannot collide with a preserved part (the zip writer throws on duplicate entries).

Not covered here: `Chartsheet.legacyDrawingHFRId` has the same dangling shape (chartsheets have no `relsExtras` at all). Left for a follow-up since the chartsheet model needs the rels-extras plumbing first.

## Testing

- New `tests/io/issue-104.test.ts` builds the reporter's scenario in memory (empty sheet, `&G` header, non-comment VML referencing one JPEG, numbered `vmlDrawing2` so a comments writer starting at 1 could not mask a dropped part) and asserts: the re-emitted `r:id` resolves through `sheet1.xml.rels`, VML + VML rels + image bytes survive, `validateXlsx` (OPC tier: every part typed, every rel resolves) reports no issues, and a second round-trip is still clean. All four cases failed before the fix for the reported reasons.
- Ran the reporter's actual `header-image.xlsx` through `loadWorkbook` → `workbookToBytes`: output now contains `sheet1.xml.rels` (`rId4` → `../drawings/vmlDrawing2.vml`), `vmlDrawing2.vml.rels`, a byte-identical `image1.jpeg`, and `<Default Extension="vml"/>` + `<Default Extension="jpeg"/>`; `validateXlsx` passes.
- `pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build && pnpm size` — all green (2310 tests).

```sh
pnpm vitest run tests/io/issue-104.test.ts
```

## Breaking changes

None. `Workbook.passthroughDefaults` is a new optional field; `relsExtras` entries may now carry `targetMode` (structurally compatible with the existing type).

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8MCz1yCqW7cTCeRyMpscm
