### PR TITLE
fix: workbook.xml was written out of CT_Workbook order (#112)

### DIFF
--- a/.changeset/fix-workbook-element-order.md
+++ b/.changeset/fix-workbook-element-order.md
@@ -1,0 +1,18 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: workbook.xml was written out of CT_Workbook order (#112)
+
+`CT_Workbook` (ECMA-376 §18.2.27) is an `xsd:sequence`, so the children of
+`<workbook>` have a normative order. Saving a workbook wrote `<definedNames>`
+straight after `<sheets>` — ahead of `<functionGroups>` and
+`<externalReferences>` — and `<pivotCaches>` ahead of `<calcPr>`. A workbook
+carrying both an external reference and a defined name therefore came back as
+a package Excel refuses to open.
+
+`workbook.xml` is now emitted in schema order: `functionGroups`,
+`externalReferences`, `definedNames`, `calcPr`, `oleSize`,
+`customWorkbookViews`, `pivotCaches`, `smartTagPr`, `smartTagTypes`,
+`fileRecoveryPr`, then any unmodeled tail (`webPublishing`,
+`webPublishObjects`, `extLst`) that was carried over from the loaded file.

--- a/src/io/save.ts
+++ b/src/io/save.ts
@@ -770,17 +770,13 @@ function serializeWorkbookXml(wb: Workbook, sheetRIds: ReadonlyArray<string>): s
     parts.push(`<sheet name="${escapeAttr(ref.sheet.title)}" sheetId="${ref.sheetId}"${stateAttr} r:id="${rId}"/>`);
   });
   parts.push('</sheets>');
-  if (wb.definedNames.length > 0) {
-    parts.push('<definedNames>');
-    for (const dn of wb.definedNames) {
-      let attrs = ` name="${escapeAttr(dn.name)}"`;
-      if (dn.scope !== undefined) attrs += ` localSheetId="${dn.scope}"`;
-      if (dn.hidden) attrs += ' hidden="1"';
-      if (dn.comment !== undefined) attrs += ` comment="${escapeAttr(dn.comment)}"`;
-      parts.push(`<definedName${attrs}>${escapeText(dn.value)}</definedName>`);
-    }
-    parts.push('</definedNames>');
-  }
+  // ECMA-376 §18.2.27 makes CT_Workbook an xsd:sequence, so the order below is
+  // normative: functionGroups, externalReferences, definedNames, calcPr,
+  // oleSize, customWorkbookViews, pivotCaches, smartTagPr, smartTagTypes,
+  // webPublishing, fileRecoveryPr, webPublishObjects, extLst. Excel rejects a
+  // workbook whose children are out of sequence. `afterSheets` is the
+  // unmodeled tail (webPublishing / webPublishObjects / extLst /
+  // mc:AlternateContent), so it goes last.
   if (wb.functionGroups) {
     const fg = serializeFunctionGroups(wb.functionGroups);
     if (fg) parts.push(fg);
@@ -793,13 +789,16 @@ function serializeWorkbookXml(wb: Workbook, sheetRIds: ReadonlyArray<string>): s
     inner.push('</externalReferences>');
     parts.push(inner.join(''));
   }
-  if (wb.pivotCaches && wb.pivotCaches.length > 0) {
-    const inner: string[] = ['<pivotCaches>'];
-    for (const pc of wb.pivotCaches) {
-      inner.push(`<pivotCache cacheId="${pc.cacheId}" r:id="${escapeAttr(pc.rId)}"/>`);
+  if (wb.definedNames.length > 0) {
+    parts.push('<definedNames>');
+    for (const dn of wb.definedNames) {
+      let attrs = ` name="${escapeAttr(dn.name)}"`;
+      if (dn.scope !== undefined) attrs += ` localSheetId="${dn.scope}"`;
+      if (dn.hidden) attrs += ' hidden="1"';
+      if (dn.comment !== undefined) attrs += ` comment="${escapeAttr(dn.comment)}"`;
+      parts.push(`<definedName${attrs}>${escapeText(dn.value)}</definedName>`);
     }
-    inner.push('</pivotCaches>');
-    parts.push(inner.join(''));
+    parts.push('</definedNames>');
   }
   if (wb.calcProperties) {
     const cp = serializeCalcProperties(wb.calcProperties);
@@ -815,6 +814,14 @@ function serializeWorkbookXml(wb: Workbook, sheetRIds: ReadonlyArray<string>): s
   if (wb.customWorkbookViews && wb.customWorkbookViews.length > 0) {
     parts.push(serializeCustomWorkbookViews(wb.customWorkbookViews));
   }
+  if (wb.pivotCaches && wb.pivotCaches.length > 0) {
+    const inner: string[] = ['<pivotCaches>'];
+    for (const pc of wb.pivotCaches) {
+      inner.push(`<pivotCache cacheId="${pc.cacheId}" r:id="${escapeAttr(pc.rId)}"/>`);
+    }
+    inner.push('</pivotCaches>');
+    parts.push(inner.join(''));
+  }
   if (wb.smartTagPr) {
     const stp = serializeSmartTagPr(wb.smartTagPr);
     if (stp) parts.push(stp);
@@ -822,12 +829,12 @@ function serializeWorkbookXml(wb: Workbook, sheetRIds: ReadonlyArray<string>): s
   if (wb.smartTagTypes && wb.smartTagTypes.length > 0) {
     parts.push(serializeSmartTagTypes(wb.smartTagTypes));
   }
-  if (wb.workbookXmlExtras?.afterSheets) {
-    for (const node of wb.workbookXmlExtras.afterSheets) parts.push(serializeChildNode(node));
-  }
   if (wb.fileRecoveryPr) {
     const fp = serializeFileRecoveryPr(wb.fileRecoveryPr);
     if (fp) parts.push(fp);
+  }
+  if (wb.workbookXmlExtras?.afterSheets) {
+    for (const node of wb.workbookXmlExtras.afterSheets) parts.push(serializeChildNode(node));
   }
   parts.push('</workbook>');
   return parts.join('');

--- a/tests/io/issue-112.test.ts
+++ b/tests/io/issue-112.test.ts
@@ -1,0 +1,121 @@
+// Regression for https://github.com/office-kit/xlsx/issues/112 — CT_Workbook
+// (ECMA-376 §18.2.27) is an xsd:sequence, so `<workbook>`'s children have a
+// normative order. The writer used to emit `<definedNames>` straight after
+// `<sheets>` — ahead of `<functionGroups>` and `<externalReferences>` — and
+// `<pivotCaches>` ahead of `<calcPr>`, producing a package Excel refuses.
+
+import { zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { fromBuffer } from '../../src/io/node';
+import { loadWorkbook } from '../../src/io/load';
+import { workbookToBytes } from '../../src/io/save';
+import { openZip } from '../../src/zip/reader';
+import { validateXlsx } from '../conformance/validate';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const MAIN_NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+
+// The reporter's fixture reduced to what the ordering needs: a workbook that
+// carries both `<externalReferences>` and `<definedNames>`, plus a `<calcPr>`
+// and a `<pivotCaches>` so the second swap shows too. The pivot cache part is
+// carried through as a passthrough — only the workbook-root link matters here.
+const buildFixture = (): Uint8Array =>
+  zipSync({
+    '[Content_Types].xml': enc.encode(
+      `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="xml" ContentType="application/xml"/>' +
+        '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+        '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+        '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' +
+        '<Override PartName="/xl/externalLinks/externalLink1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml"/>' +
+        '<Override PartName="/xl/pivotCache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/>' +
+        '</Types>',
+    ),
+    '_rels/.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/officeDocument" Target="xl/workbook.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/workbook.xml': enc.encode(
+      `${XML_DECL}<workbook xmlns="${MAIN_NS}" xmlns:r="${REL_NS}">` +
+        '<sheets><sheet name="Tabelle1" sheetId="1" r:id="rId1"/></sheets>' +
+        '<externalReferences><externalReference r:id="rId2"/></externalReferences>' +
+        '<definedNames><definedName name="Marke">Tabelle1!$A$1</definedName></definedNames>' +
+        '<calcPr calcId="191029"/>' +
+        '<pivotCaches><pivotCache cacheId="1" r:id="rId3"/></pivotCaches>' +
+        '</workbook>',
+    ),
+    'xl/_rels/workbook.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/worksheet" Target="worksheets/sheet1.xml"/>` +
+        `<Relationship Id="rId2" Type="${REL_NS}/externalLink" Target="externalLinks/externalLink1.xml"/>` +
+        `<Relationship Id="rId3" Type="${REL_NS}/pivotCacheDefinition" Target="pivotCache/pivotCacheDefinition1.xml"/>` +
+        `<Relationship Id="rId9" Type="${REL_NS}/styles" Target="styles.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/styles.xml': enc.encode(
+      `${XML_DECL}<styleSheet xmlns="${MAIN_NS}">` +
+        '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+        '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
+        '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+        '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+        '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>' +
+        '</styleSheet>',
+    ),
+    'xl/worksheets/sheet1.xml': enc.encode(
+      `${XML_DECL}<worksheet xmlns="${MAIN_NS}" xmlns:r="${REL_NS}">` +
+        '<sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData></worksheet>',
+    ),
+    'xl/externalLinks/externalLink1.xml': enc.encode(
+      `${XML_DECL}<externalLink xmlns="${MAIN_NS}" xmlns:r="${REL_NS}">` +
+        '<externalBook r:id="rId1"><sheetNames><sheetName val="Extern"/></sheetNames></externalBook>' +
+        '</externalLink>',
+    ),
+    'xl/externalLinks/_rels/externalLink1.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/externalLinkPath" Target="Preise.xlsx" TargetMode="External"/>` +
+        '</Relationships>',
+    ),
+    'xl/pivotCache/pivotCacheDefinition1.xml': enc.encode(
+      `${XML_DECL}<pivotCacheDefinition xmlns="${MAIN_NS}" xmlns:r="${REL_NS}" recordCount="0">` +
+        '<cacheSource type="worksheet"><worksheetSource ref="A1:A1" sheet="Tabelle1"/></cacheSource>' +
+        '<cacheFields count="0"/></pivotCacheDefinition>',
+    ),
+  });
+
+const roundTrip = async (): Promise<Uint8Array> =>
+  workbookToBytes(await loadWorkbook(fromBuffer(buildFixture())));
+
+const workbookXml = async (bytes: Uint8Array): Promise<string> => {
+  const archive = await openZip(fromBuffer(bytes));
+  try {
+    return dec.decode(archive.read('xl/workbook.xml'));
+  } finally {
+    archive.close();
+  }
+};
+
+describe('issue #112 — workbook.xml keeps the CT_Workbook element sequence', () => {
+  it('writes externalReferences before definedNames', async () => {
+    const xml = await workbookXml(await roundTrip());
+    expect(xml.indexOf('<externalReferences>')).toBeGreaterThan(-1);
+    expect(xml.indexOf('<externalReferences>')).toBeLessThan(xml.indexOf('<definedNames>'));
+  });
+
+  it('writes calcPr before pivotCaches', async () => {
+    const xml = await workbookXml(await roundTrip());
+    expect(xml.indexOf('<calcPr')).toBeGreaterThan(-1);
+    expect(xml.indexOf('<calcPr')).toBeLessThan(xml.indexOf('<pivotCaches>'));
+  });
+
+  it('validates against the CT_Workbook schema', async () => {
+    const result = await validateXlsx(await roundTrip());
+    expect(result.issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`workbook.xml` was serialized with its children out of the `CT_Workbook`
sequence. A workbook that carries both an `<externalReferences>` block and a
`<definedNames>` block came back from a round-trip as a package Excel refuses
to open.

## Motivation

`CT_Workbook` (ECMA-376 §18.2.27) is an `xsd:sequence`, so the order of
`<workbook>`'s children is normative. The writer emitted:

- `<definedNames>` straight after `<sheets>`, ahead of `<functionGroups>` and
  `<externalReferences>`;
- `<pivotCaches>` ahead of `<calcPr>`;
- `<fileRecoveryPr>` after the unmodeled tail (`extLst` and friends) that the
  schema puts last.

Nothing warned at save time — the package only fails when Excel opens it.

Closes #112

## Changes

- `serializeWorkbookXml` now emits the modeled children in schema order:
  `functionGroups`, `externalReferences`, `definedNames`, `calcPr`, `oleSize`,
  `customWorkbookViews`, `pivotCaches`, `smartTagPr`, `smartTagTypes`,
  `fileRecoveryPr`, then the carried-over unmodeled tail.

No API surface changes.

## Testing

- New `tests/io/issue-112.test.ts` — a minimal package reduced from the
  reporter's fixture (external reference + defined name + `calcPr` +
  `pivotCaches`). It asserts both orderings and runs the full
  OPC + XSD + semantic conformance validator over the output. All three cases
  fail on `main` (xmllint reports `Element 'externalReferences': This element
  is not expected`) and pass with the fix.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (2317 tests) green locally.

```sh
pnpm vitest run tests/io/issue-112.test.ts
```

## Breaking changes

None

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->
