### PR TITLE
fix: styles.xml lost dxfs, tableStyles, colors and extLst on save (#113)

### DIFF
--- a/.changeset/fix-styles-tail-roundtrip.md
+++ b/.changeset/fix-styles-tail-roundtrip.md
@@ -1,0 +1,18 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: styles.xml lost dxfs, tableStyles, colors and extLst on save (#113)
+
+Everything after `<cellStyles>` in `xl/styles.xml` was dropped when a loaded
+workbook was saved again. `<dxfs>` was only written when the pool held
+entries, and `<tableStyles>`, `<colors>` and `<extLst>` — where Excel keeps
+custom table styles, the MRU colour palette and the x14/x15 slicer and
+timeline styles — were never read in the first place. Every workbook Excel
+writes carries at least `<dxfs>` and `<tableStyles>`, so this hit essentially
+any real file.
+
+`Stylesheet` now carries the unmodeled tail (`stylesXmlTail`) verbatim and the
+writer re-emits it after `<dxfs>`, where `CT_Stylesheet` (ECMA-376 §18.8.39)
+puts it. `<dxfs count="0"/>` is now always written, matching Excel — a
+conditional-formatting rule's `dxfId` is an index into that list.

--- a/src/styles/stylesheet-reader.ts
+++ b/src/styles/stylesheet-reader.ts
@@ -40,6 +40,18 @@ const CELLSTYLE_TAG = qname(SHEET_MAIN_NS, 'cellStyle');
 const DXFS_TAG = qname(SHEET_MAIN_NS, 'dxfs');
 const DXF_TAG = qname(SHEET_MAIN_NS, 'dxf');
 const XF_TAG = qname(SHEET_MAIN_NS, 'xf');
+// Every `<styleSheet>` child this reader turns into typed model state. Anything
+// else — `<tableStyles>`, `<colors>`, `<extLst>` — is kept verbatim instead.
+const MODELED_SECTION_TAGS: ReadonlySet<string> = new Set([
+  NUMFMTS_TAG,
+  FONTS_TAG,
+  FILLS_TAG,
+  BORDERS_TAG,
+  CELLSTYLEXFS_TAG,
+  CELLXFS_TAG,
+  CELLSTYLES_TAG,
+  DXFS_TAG,
+]);
 const FONT_TAG = qname(SHEET_MAIN_NS, 'font');
 const FILL_TAG = qname(SHEET_MAIN_NS, 'fill');
 const BORDER_TAG = qname(SHEET_MAIN_NS, 'border');
@@ -139,6 +151,9 @@ export function parseStylesheetXml(bytes: Uint8Array | string): Stylesheet {
       w._dxfIdByKey = new Map(dxfs.map((d, i) => [stableStringify(d), i]));
     }
   }
+
+  const tail = root.children.filter((child) => !MODELED_SECTION_TAGS.has(child.name));
+  if (tail.length > 0) ss.stylesXmlTail = tail;
 
   rebuildIndexes(ss);
   return ss;

--- a/src/styles/stylesheet-writer.ts
+++ b/src/styles/stylesheet-writer.ts
@@ -104,8 +104,11 @@ function buildStylesheetTree(ss: Stylesheet): XmlNode {
   }
 
   // dxfs — differential styles referenced by conditional formatting and tables.
+  // Emitted even when empty: Excel writes `<dxfs count="0"/>` into every
+  // workbook, and a `dxfId` is an index into this list, so the element is the
+  // anchor conditional-formatting rules count from.
   const dxfs = getDxfs(ss as StylesheetWithDxfs);
-  if (dxfs.length > 0) {
+  {
     const dxfsEl = el(DXFS_TAG, { count: String(dxfs.length) });
     for (const dxf of dxfs) {
       const dxfEl = el(DXF_TAG);
@@ -120,6 +123,12 @@ function buildStylesheetTree(ss: Stylesheet): XmlNode {
       dxfsEl.children.push(dxfEl);
     }
     root.children.push(dxfsEl);
+  }
+
+  // tableStyles / colors / extLst, carried over verbatim from the loaded file.
+  // CT_Stylesheet (ECMA-376 §18.8.39) puts all three after <dxfs>.
+  if (ss.stylesXmlTail) {
+    for (const node of ss.stylesXmlTail) root.children.push(node);
   }
 
   return root;

--- a/src/styles/stylesheet.ts
+++ b/src/styles/stylesheet.ts
@@ -55,6 +55,14 @@ export interface Stylesheet {
   cellStyleXfs: CellXf[];
   /** Named styles (Excel's "Cell Styles" gallery; populated by addNamedStyle). */
   namedStyles?: Array<import('./named-styles').StylesheetNamedStyle>;
+  /**
+   * The tail of `<styleSheet>` this model doesn't cover — `<tableStyles>`,
+   * `<colors>` and `<extLst>` (which is where Excel keeps its x14/x15 slicer
+   * and timeline styles). Captured verbatim in document order so re-saving a
+   * loaded workbook keeps them; CT_Stylesheet puts all three after `<dxfs>`,
+   * so the writer appends them there.
+   */
+  stylesXmlTail?: Array<import('../xml/tree').XmlNode>;
 
   // Internal dedup maps. Underscore-prefixed so JSON / structuredClone
   // serialisation can choose to skip them; never part of the public API.

--- a/tests/styles/issue-113.test.ts
+++ b/tests/styles/issue-113.test.ts
@@ -1,0 +1,127 @@
+// Regression for https://github.com/office-kit/xlsx/issues/113 — everything
+// after `<cellStyles>` in xl/styles.xml was dropped on save. `<dxfs>` was only
+// written when it held entries, and `<tableStyles>`, `<colors>` and `<extLst>`
+// (where Excel keeps its x14 slicer / timeline styles) were never read at all,
+// so they disappeared from every workbook that went through load → save.
+
+import { zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { fromBuffer } from '../../src/io/node';
+import { loadWorkbook } from '../../src/io/load';
+import { workbookToBytes } from '../../src/io/save';
+import { openZip } from '../../src/zip/reader';
+import { validateXlsx } from '../conformance/validate';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const MAIN_NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+const X14_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2009/9/main';
+
+// Excel's own styles.xml tail: a dxf a table style points at, the table-style
+// defaults, an MRU colour and the x14 extension that carries slicer/timeline
+// styles.
+const STYLES_TAIL =
+  '<dxfs count="1"><dxf><fill><patternFill><bgColor rgb="FFFFC7CE"/></patternFill></fill></dxf></dxfs>' +
+  '<tableStyles count="1" defaultTableStyle="TableStyleMedium2" defaultPivotStyle="PivotStyleLight16">' +
+  '<tableStyle name="Firmenstil" pivot="0" count="1"><tableStyleElement type="wholeTable" dxfId="0"/></tableStyle>' +
+  '</tableStyles>' +
+  '<colors><mruColors><color rgb="FF3366CC"/></mruColors></colors>' +
+  `<extLst><ext uri="{EB79DEF2-80B8-43e5-95BD-54CBDDF9020C}" xmlns:x14="${X14_NS}">` +
+  '<x14:slicerStyles defaultSlicerStyle="SlicerStyleLight1"/></ext></extLst>';
+
+const buildFixtureWithTail = (tail: string): Uint8Array =>
+  zipSync({
+    '[Content_Types].xml': enc.encode(
+      `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="xml" ContentType="application/xml"/>' +
+        '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+        '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+        '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' +
+        '</Types>',
+    ),
+    '_rels/.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/officeDocument" Target="xl/workbook.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/workbook.xml': enc.encode(
+      `${XML_DECL}<workbook xmlns="${MAIN_NS}" xmlns:r="${REL_NS}">` +
+        '<sheets><sheet name="Tabelle1" sheetId="1" r:id="rId1"/></sheets></workbook>',
+    ),
+    'xl/_rels/workbook.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/worksheet" Target="worksheets/sheet1.xml"/>` +
+        `<Relationship Id="rId9" Type="${REL_NS}/styles" Target="styles.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/styles.xml': enc.encode(
+      `${XML_DECL}<styleSheet xmlns="${MAIN_NS}">` +
+        '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+        '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
+        '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+        '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+        '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>' +
+        '<cellStyles count="1"><cellStyle name="Standard" xfId="0" builtinId="0"/></cellStyles>' +
+        tail +
+        '</styleSheet>',
+    ),
+    'xl/worksheets/sheet1.xml': enc.encode(
+      `${XML_DECL}<worksheet xmlns="${MAIN_NS}" xmlns:r="${REL_NS}">` +
+        '<sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData></worksheet>',
+    ),
+  });
+
+const buildFixture = (): Uint8Array => buildFixtureWithTail(STYLES_TAIL);
+
+const roundTrip = async (bytes: Uint8Array = buildFixture()): Promise<Uint8Array> =>
+  workbookToBytes(await loadWorkbook(fromBuffer(bytes)));
+
+const stylesXml = async (bytes: Uint8Array): Promise<string> => {
+  const archive = await openZip(fromBuffer(bytes));
+  try {
+    return dec.decode(archive.read('xl/styles.xml'));
+  } finally {
+    archive.close();
+  }
+};
+
+describe('issue #113 — styles.xml keeps everything after <cellStyles>', () => {
+  it('keeps tableStyles, colors and extLst across a round-trip', async () => {
+    const xml = await stylesXml(await roundTrip());
+    expect(xml).toContain('<tableStyle name="Firmenstil"');
+    expect(xml).toContain('<tableStyleElement type="wholeTable" dxfId="0"/>');
+    expect(xml).toContain('defaultTableStyle="TableStyleMedium2"');
+    expect(xml).toContain('defaultPivotStyle="PivotStyleLight16"');
+    expect(xml).toContain('<color rgb="FF3366CC"/>');
+    expect(xml).toContain('{EB79DEF2-80B8-43e5-95BD-54CBDDF9020C}');
+    expect(xml).toContain('slicerStyles defaultSlicerStyle="SlicerStyleLight1"');
+  });
+
+  it('keeps them in CT_Stylesheet order, after <dxfs>', async () => {
+    const xml = await stylesXml(await roundTrip());
+    const order = ['<dxfs', '<tableStyles', '<colors', 'extLst'].map((tag) => xml.indexOf(tag));
+    expect(order.every((i) => i > -1)).toBe(true);
+    expect([...order].sort((a, b) => a - b)).toEqual(order);
+  });
+
+  it('writes <dxfs count="0"/> even when the pool is empty', async () => {
+    // Excel puts the element in every workbook it writes, and a rule's dxfId
+    // is an index into it, so the empty anchor has to survive too.
+    const emptyDxfs = buildFixtureWithTail('<dxfs count="0"/>');
+    const xml = await stylesXml(await roundTrip(emptyDxfs));
+    expect(xml).toContain('<dxfs count="0"/>');
+  });
+
+  it('is stable across a second round-trip and validates', async () => {
+    const once = await roundTrip();
+    const twice = await roundTrip(once);
+    expect(await stylesXml(twice)).toEqual(await stylesXml(once));
+    const result = await validateXlsx(twice);
+    expect(result.issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Everything after `<cellStyles>` in `xl/styles.xml` was lost when a loaded
workbook was saved again — `<dxfs>`, `<tableStyles>`, `<colors>` and
`<extLst>`. Every workbook Excel writes carries at least `<dxfs>` and
`<tableStyles>`, so this hit essentially any real file.

## Motivation

Two separate gaps:

- The writer only emitted `<dxfs>` when the pool held entries, so Excel's
  `<dxfs count="0"/>` vanished. That element is the anchor a
  conditional-formatting rule's `dxfId` indexes into.
- `<tableStyles>`, `<colors>` and `<extLst>` were never read at all.
  `<extLst>` is where Excel keeps its x14/x15 slicer and timeline styles, and
  `<tableStyles>` holds every custom Excel-table style in the workbook.

Closes #113

## Changes

- `Stylesheet` gains an optional `stylesXmlTail` — the `<styleSheet>` children
  the model doesn't cover, captured verbatim in document order.
- `parseStylesheetXml` fills it with anything that isn't one of the eight
  modeled sections; `stylesheetToBytes` re-emits it after `<dxfs>`, where
  `CT_Stylesheet` (ECMA-376 §18.8.39) puts `tableStyles` / `colors` / `extLst`.
- `<dxfs count="N"/>` is now written unconditionally, matching what Excel puts
  in every workbook.

## Testing

- New `tests/styles/issue-113.test.ts` — a package whose styles.xml carries a
  dxf, a custom table style pointing at it by `dxfId`, an MRU colour and the
  x14 `slicerStyles` extension. It asserts the tail survives, that it comes
  back in `CT_Stylesheet` order, that an empty `<dxfs count="0"/>` survives,
  and that a second round-trip is byte-identical and passes the full
  OPC + XSD + semantic validator. Three of the four fail on `main`.
- `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm test` (2318 tests) green
  locally.

```sh
pnpm vitest run tests/styles/issue-113.test.ts
```

## Breaking changes

None. `stylesXmlTail` is a new optional field on `Stylesheet`; existing
stylesheets built in code are unaffected apart from now emitting
`<dxfs count="0"/>`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->
