### PR TITLE
fix: empty cached formula value (<v/>) and t="str" were dropped on save (#115)

### DIFF
--- a/.changeset/fix-empty-cached-formula-value.md
+++ b/.changeset/fix-empty-cached-formula-value.md
@@ -1,0 +1,17 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: an empty cached formula value and its `t="str"` were dropped on save (#115)
+
+`<c r="A1" t="str"><f>[1]Extern!$A$1</f><v/></c>` came back as
+`<c r="A1"><f>[1]Extern!$A$1</f></c>`: the reader collapsed an empty `<v/>`
+and an absent `<v>` into the same "no cached value" state, so the writer had
+nothing left to emit the type from.
+
+It matters for formulas that reference another workbook — Excel cannot
+recalculate those without opening the other file, so the cached value is the
+only thing it has to display. An empty `<v/>` is now read as a cached empty
+string and written back with its `t="str"`; a genuinely absent `<v>` still
+means "no cached value", and an empty `<v/>` on a numeric cell still carries
+no number.

--- a/src/worksheet/reader.ts
+++ b/src/worksheet/reader.ts
@@ -1407,7 +1407,11 @@ const readCell = (
   // ---- formula path ------------------------------------------------------
   if (fNode) {
     const cell = setCell(ws, coord.row, coord.col, null, styleId);
-    const cachedRaw = vNode?.text;
+    // `<v/>` and a missing `<v>` are different states: Excel writes the former
+    // for a formula whose cached result is the empty string (common for links
+    // into a workbook it cannot reach), and that cached value is the only
+    // thing it has to display until the link resolves.
+    const cachedRaw = vNode === undefined ? undefined : (vNode.text ?? '');
     const cached = decodeCachedValue(cachedRaw, t);
     handleFormula(cell, fNode, coord, cached, sharedFormulas);
     return;
@@ -1482,12 +1486,13 @@ const readInlineString = (isNode: XmlNode | undefined): string => {
 };
 
 const decodeCachedValue = (raw: string | undefined, t: string): number | string | boolean | undefined => {
-  if (raw === undefined || raw === '') return undefined;
+  if (raw === undefined) return undefined;
   switch (t) {
     case 'n':
-      return Number.parseFloat(raw);
+      // An empty `<v/>` under the (default) numeric type carries no number.
+      return raw === '' ? undefined : Number.parseFloat(raw);
     case 'b':
-      return raw === '1';
+      return raw === '' ? undefined : raw === '1';
     case 'str':
       return raw;
     case 'e':

--- a/src/worksheet/writer.ts
+++ b/src/worksheet/writer.ts
@@ -393,9 +393,12 @@ const serializeFormulaCell = (ref: string, styleAttr: string, f: FormulaValue): 
       valueAttr = ' t="b"';
       vEl = `<v>${cached ? '1' : '0'}</v>`;
     } else {
-      // String result of a formula — use t="str", not the sst path.
+      // String result of a formula — use t="str", not the sst path. An empty
+      // result still needs both the type and the `<v/>`: that is what Excel
+      // displays for a formula it cannot recalculate.
       valueAttr = ' t="str"';
-      vEl = `<v>${escapeXmlText(escapeCellString(cached))}</v>`;
+      const text = escapeXmlText(escapeCellString(cached));
+      vEl = text.length > 0 ? `<v>${text}</v>` : '<v/>';
     }
   }
   return `<c r="${ref}"${styleAttr}${valueAttr}>${fEl}${vEl}</c>`;

--- a/tests/worksheet/issue-115.test.ts
+++ b/tests/worksheet/issue-115.test.ts
@@ -1,0 +1,60 @@
+// Regression for https://github.com/office-kit/xlsx/issues/115 — a formula
+// cell whose cached result is the empty string (`<c t="str"><f>…</f><v/></c>`)
+// came back with both the `t="str"` and the `<v/>` gone. The reader collapsed
+// an empty `<v/>` and an absent `<v>` into the same "no cached value" state.
+//
+// It matters for links into another workbook: Excel cannot recalculate those
+// without opening the other file, so the cached value is the only thing it has
+// to display.
+
+import { describe, expect, it } from 'vitest';
+import { setFormula } from '../../src/cell/cell';
+import { makeSharedStrings } from '../../src/workbook/shared-strings';
+import { parseWorksheetXml } from '../../src/worksheet/reader';
+import { worksheetToBytes } from '../../src/worksheet/writer';
+import { getCell, makeWorksheet, setCell } from '../../src/worksheet/worksheet';
+
+const MAIN_NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+const REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+const sheetXml = (cells: string): string =>
+  `<worksheet xmlns="${MAIN_NS}" xmlns:r="${REL_NS}"><sheetData><row r="1">${cells}</row></sheetData></worksheet>`;
+
+describe('issue #115 — an empty cached formula value survives a round-trip', () => {
+  it('keeps t="str" and <v/> for a formula whose cached result is empty', () => {
+    const ws = parseWorksheetXml(sheetXml('<c r="A1" t="str"><f>[1]Extern!$A$1</f><v/></c>'), 'Tabelle1', {
+      sharedStrings: [],
+    });
+    const value = getCell(ws, 1, 1)?.value;
+    expect(value).toMatchObject({ kind: 'formula', formula: '[1]Extern!$A$1', cachedValue: '' });
+
+    const out = new TextDecoder().decode(worksheetToBytes(ws, { sharedStrings: makeSharedStrings() }));
+    expect(out).toContain('<c r="A1" t="str"><f>[1]Extern!$A$1</f><v/></c>');
+  });
+
+  it('still reports no cached value when <v> is absent altogether', () => {
+    const ws = parseWorksheetXml(sheetXml('<c r="A1"><f>SUM(B1:B2)</f></c>'), 'Tabelle1', {
+      sharedStrings: [],
+    });
+    const value = getCell(ws, 1, 1)?.value as { cachedValue?: unknown };
+    expect(value.cachedValue).toBeUndefined();
+
+    const out = new TextDecoder().decode(worksheetToBytes(ws, { sharedStrings: makeSharedStrings() }));
+    expect(out).toContain('<c r="A1"><f>SUM(B1:B2)</f></c>');
+  });
+
+  it('treats an empty <v/> under the numeric default as no cached number', () => {
+    const ws = parseWorksheetXml(sheetXml('<c r="A1"><f>SUM(B1:B2)</f><v/></c>'), 'Tabelle1', {
+      sharedStrings: [],
+    });
+    const value = getCell(ws, 1, 1)?.value as { cachedValue?: unknown };
+    expect(value.cachedValue).toBeUndefined();
+  });
+
+  it('round-trips a non-empty cached string unchanged', () => {
+    const ws = makeWorksheet('Tabelle1');
+    setFormula(setCell(ws, 1, 1), 'A2&""', { cachedValue: 'Text' });
+    const out = new TextDecoder().decode(worksheetToBytes(ws, { sharedStrings: makeSharedStrings() }));
+    expect(out).toContain('<c r="A1" t="str"><f>A2&amp;""</f><v>Text</v></c>');
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

A formula cell whose cached result is the empty string —
`<c r="A1" t="str"><f>[1]Extern!$A$1</f><v/></c>` — came back from a
round-trip as `<c r="A1"><f>[1]Extern!$A$1</f></c>`, losing both the cached
value and the cell type.

## Motivation

`decodeCachedValue` treated `raw === ''` the same as `raw === undefined`, so
an empty `<v/>` and an absent `<v>` collapsed into the same "no cached value"
state. With no cached value left, the writer had nothing to derive `t="str"`
from either.

This bites formulas that reference another workbook: Excel cannot recalculate
them without opening the other file, so the cached value is the only thing it
has to display.

Closes #115

## Changes

- The reader now distinguishes a present-but-empty `<v/>` from a missing
  `<v>`: the former reads as a cached empty string, the latter still yields no
  cached value.
- An empty `<v/>` on a cell using the default numeric type (or `t="b"`) still
  carries no value — an empty string is not a number or a boolean.
- The writer emits `<v/>` rather than `<v></v>` for an empty cached string, so
  the part comes back byte-identical to what Excel wrote.

## Testing

- New `tests/worksheet/issue-115.test.ts` — four cases: the empty cached
  string round-trips with its `t="str"`, an absent `<v>` still means no cached
  value, an empty `<v/>` on a numeric cell carries no number, and a non-empty
  cached string is unaffected. The first fails on `main`.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (2321 tests) green locally.

```sh
pnpm vitest run tests/worksheet/issue-115.test.ts
```

## Breaking changes

None.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->
