### PR TITLE
fix: rich text runs in sharedStrings were flattened to plain text on save (#114)

### DIFF
--- a/.changeset/fix-shared-string-rich-text.md
+++ b/.changeset/fix-shared-string-rich-text.md
@@ -1,0 +1,19 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: rich text was flattened to plain text on save (#114)
+
+A shared string built from `<r>` runs came back as a single plain `<t>`: the
+loader collapsed rich-text `<si>` entries into their concatenated text before
+the worksheet reader saw them, so a cell with a bold first half round-tripped
+uniformly unformatted. Inline strings (`<c t="inlineStr"><is>`) lost their runs
+the same way on read.
+
+Rich-text `<si>` and `<is>` bodies now go through one CT_Rst parser and become
+`{ kind: 'rich-text' }` cell values, so per-run fonts survive. Cells holding
+rich text are written into `xl/sharedStrings.xml` as `<si><r>…</r></si>` —
+where Excel itself stores them — instead of being inlined per cell, so a
+formatted string repeated across cells costs one entry rather than one copy
+each. `<r>` runs with no `<rPr>` stay separate runs, since that is how Excel
+writes the unformatted half of a rich string.

--- a/src/io/load.ts
+++ b/src/io/load.ts
@@ -287,14 +287,10 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
       }
     }
   }
-  // The worksheet reader takes plain strings; rich-text SST entries are
-  // flattened to their concatenated text body so cell values stay simple.
-  // (Rich-text fidelity round-trip on read needs a sst entry → cell-value
-  // bridge that produces a rich-text cell; for now Excel re-write still works
-  // because we only flatten on read, not on write.)
-  const sst: ReadonlyArray<string> = (sharedStrings?.entries ?? []).map((e) =>
-    typeof e === 'string' ? e : e.runs.map((r) => r.text).join(''),
-  );
+  // Entries reach the worksheet reader as-is: a rich-text `<si>` becomes a
+  // rich-text cell value, so the per-run formatting Excel stored survives the
+  // round-trip instead of collapsing into the concatenated text body.
+  const sst = sharedStrings?.entries ?? [];
 
   // 4c. styles.xml — optional. Same default-or-rels lookup as sst.
   let styles: ReturnType<typeof parseStylesheetXml> | undefined;

--- a/src/streaming/read-only.ts
+++ b/src/streaming/read-only.ts
@@ -6,7 +6,7 @@
 // `iterParse`. The iterator streams rows without materialising the full sheet
 // in memory.
 
-import { type SharedStringsTable, parseSharedStringsXml } from '../workbook/shared-strings';
+import { makeSharedStrings, parseSharedStringsXml, type SharedStringsTable } from '../workbook/shared-strings';
 import { ARC_CONTENT_TYPES, ARC_ROOT_RELS, ARC_SHARED_STRINGS, ARC_STYLE, REL_NS, SHEET_MAIN_NS } from '../xml/namespaces';
 import { findById, relsFromBytes } from '../packaging/relationships';
 import { manifestFromBytes } from '../packaging/manifest';
@@ -501,7 +501,7 @@ export async function loadWorkbookStream(
   const entryMap = new Map<string, SheetEntry>();
   for (const e of sheetEntries) entryMap.set(e.name, e);
 
-  let sst: SharedStringsTable = { entries: [], index: new Map() };
+  let sst: SharedStringsTable = makeSharedStrings();
   if (archive.has(ARC_SHARED_STRINGS)) {
     sst = parseSharedStringsXml(archive.read(ARC_SHARED_STRINGS));
   }

--- a/src/workbook/shared-strings.ts
+++ b/src/workbook/shared-strings.ts
@@ -7,14 +7,15 @@
 //
 // Rich-text entries are kept as their full `RichText` runs so per-run fonts
 // (bold / italic / colour / size / …) survive the round-trip. Plain strings
-// still dedup against literal text; rich text is kept distinct per-cell
-// (Excel's writer doesn't dedupe rich-text either — formatting equality is
-// rarely worth comparing).
+// dedup against literal text; rich text dedups against the structural shape of
+// its runs, so a string that is bold in one cell and plain in another still
+// gets two slots.
 
 import type { RichText } from '../cell/rich-text';
 import { type Color, colorToHex } from '../styles/colors';
 import { escapeCellString, escapeXmlAttr, escapeXmlText, unescapeCellString } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
+import { stableStringify } from '../utils/stable-stringify';
 import { qname, SHEET_MAIN_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
 import { findChild, findChildren, type XmlNode } from '../xml/tree';
@@ -37,10 +38,12 @@ export interface SharedStringsTable {
   entries: SharedStringEntry[];
   /** Reverse lookup keyed by literal text — rich-text entries skip this map. */
   index: Map<string, number>;
+  /** Reverse lookup for rich-text entries, keyed by the structure of their runs. */
+  richIndex: Map<string, number>;
 }
 
 export function makeSharedStrings(): SharedStringsTable {
-  return { entries: [], index: new Map() };
+  return { entries: [], index: new Map(), richIndex: new Map() };
 }
 
 /**
@@ -54,6 +57,21 @@ export function addSharedString(table: SharedStringsTable, value: string): numbe
   const id = table.entries.length;
   table.entries.push(value);
   table.index.set(value, id);
+  return id;
+}
+
+/**
+ * Insert a rich-text entry and return its index. Deduped on the structure of
+ * the runs, so the same formatted string used in 100 cells lands in one slot —
+ * which is how Excel stores it.
+ */
+export function addSharedRichText(table: SharedStringsTable, runs: RichText): number {
+  const key = stableStringify(runs);
+  const cached = table.richIndex.get(key);
+  if (cached !== undefined) return cached;
+  const id = table.entries.length;
+  table.entries.push({ kind: 'rich-text', runs });
+  table.richIndex.set(key, id);
   return id;
 }
 
@@ -116,17 +134,27 @@ export function parseSharedStringsXml(bytes: Uint8Array | string): SharedStrings
   }
   const table = makeSharedStrings();
   for (const si of findChildren(root, SI_TAG)) {
-    const entry = parseSi(si);
+    const entry = parseRichString(si);
     // Don't dedup — Excel preserves duplicate `<si>` entries by index, and the
     // worksheet `t="s"` references depend on slot, not on text equality.
     const id = table.entries.length;
     table.entries.push(entry);
-    if (typeof entry === 'string' && !table.index.has(entry)) table.index.set(entry, id);
+    if (typeof entry === 'string') {
+      if (!table.index.has(entry)) table.index.set(entry, id);
+    } else {
+      const key = stableStringify(entry.runs);
+      if (!table.richIndex.has(key)) table.richIndex.set(key, id);
+    }
   }
   return table;
 }
 
-const parseSi = (si: XmlNode): SharedStringEntry => {
+/**
+ * Parse a `CT_Rst` body — the shape shared by `<si>` in sharedStrings.xml and
+ * `<is>` in an inline-string cell. Returns rich text when the body is built
+ * from `<r>` runs, and the plain concatenated text otherwise.
+ */
+export const parseRichString = (si: XmlNode): SharedStringEntry => {
   // Rich-text si has one or more <r> children. Plain si has a single <t>.
   const runEls = findChildren(si, R_TAG);
   if (runEls.length > 0) {
@@ -235,11 +263,8 @@ const serializeSi = (value: SharedStringEntry): string => {
   return `<si>${serializeRichTextRuns(value.runs)}</si>`;
 };
 
-/**
- * Serialise a sequence of `<r>...<r>` runs — shared by the SST `<si>` writer
- * and the worksheet's inline-string (`t="inlineStr"`) cell writer.
- */
-export function serializeRichTextRuns(runs: import('../cell/rich-text').RichText): string {
+/** Serialise a sequence of `<r>…</r>` runs into an `<si>` / `<is>` body. */
+function serializeRichTextRuns(runs: import('../cell/rich-text').RichText): string {
   const parts: string[] = [];
   for (const run of runs) {
     parts.push('<r>');

--- a/src/worksheet/reader.ts
+++ b/src/worksheet/reader.ts
@@ -8,6 +8,7 @@
 
 import {
   type Cell,
+  type CellValue,
   type ExcelErrorCode,
   type FormulaKind,
   setArrayFormula,
@@ -26,6 +27,7 @@ import { MARKUP_COMPAT_NS, REL_NS, SHEET_MAIN_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
 import { serializeXml } from '../xml/serializer';
 import { findChild, findChildren, type XmlNode } from '../xml/tree';
+import { parseRichString, type SharedStringEntry } from '../workbook/shared-strings';
 import type { AutoFilter, FilterColumn } from './auto-filter';
 import { parseMultiCellRange, parseRange } from './cell-range';
 import type { LegacyComment } from './comments';
@@ -90,7 +92,6 @@ const C_TAG = `{${SHEET_MAIN_NS}}c`;
 const V_TAG = `{${SHEET_MAIN_NS}}v`;
 const F_TAG = `{${SHEET_MAIN_NS}}f`;
 const IS_TAG = `{${SHEET_MAIN_NS}}is`;
-const T_TAG = `{${SHEET_MAIN_NS}}t`;
 const MERGE_CELLS_TAG = `{${SHEET_MAIN_NS}}mergeCells`;
 const MERGE_CELL_TAG = `{${SHEET_MAIN_NS}}mergeCell`;
 const SHEET_VIEWS_TAG = `{${SHEET_MAIN_NS}}sheetViews`;
@@ -173,8 +174,12 @@ const FIRST_FOOTER_TAG = `{${SHEET_MAIN_NS}}firstFooter`;
 
 /** Inputs the worksheet reader needs from the surrounding workbook context. */
 export interface WorksheetReadContext {
-  /** Resolved shared-strings table. Pass `[]` when no sst is present. */
-  sharedStrings: ReadonlyArray<string>;
+  /**
+   * Resolved shared-strings table. Pass `[]` when no sst is present. Entries
+   * may be rich text — those become `{ kind: 'rich-text' }` cell values so the
+   * per-run formatting Excel stored survives.
+   */
+  sharedStrings: ReadonlyArray<SharedStringEntry>;
   /** This worksheet's `_rels/sheetN.xml.rels`. Used to resolve external hyperlink targets and table parts. */
   rels?: Relationships;
   /** Resolves a worksheet-rels rId pointing at xl/tables/tableN.xml into a parsed TableDefinition. */
@@ -1414,7 +1419,7 @@ const readCell = (
   }
 
   // ---- non-formula values ------------------------------------------------
-  let value: number | string | boolean | { kind: 'error'; code: ExcelErrorCode } | null = null;
+  let value: CellValue = null;
   switch (t) {
     case 'n':
       value = vNode?.text !== undefined && vNode.text !== '' ? Number.parseFloat(vNode.text) : null;
@@ -1433,7 +1438,7 @@ const readCell = (
           `worksheet: shared-string index ${idx} out of range [0, ${ctx.sharedStrings.length})`,
         );
       }
-      value = sst;
+      value = typeof sst === 'string' ? sst : { kind: 'rich-text', runs: sst.runs };
       break;
     }
     case 'b':
@@ -1467,18 +1472,16 @@ const parseStyleId = (raw: string): number => {
   return n;
 };
 
-/** Inline-string body — concatenates `<is>/<t>` text runs. Rich runs lose formatting in stage-1. */
-const readInlineString = (isNode: XmlNode | undefined): string => {
+/**
+ * Inline-string body (`<c t="inlineStr"><is>…</is></c>`). `<is>` is a CT_Rst —
+ * the same shape as an `<si>` in sharedStrings.xml — so it goes through the
+ * same parser, and a body built from `<r>` runs keeps its per-run formatting
+ * instead of collapsing to the concatenated text.
+ */
+const readInlineString = (isNode: XmlNode | undefined): CellValue => {
   if (!isNode) return '';
-  const direct = findChild(isNode, T_TAG);
-  if (direct) return direct.text ?? '';
-  // Rich inline string — concatenate every <r>/<t>.
-  let out = '';
-  for (const child of isNode.children) {
-    const t = findChild(child, T_TAG);
-    if (t?.text) out += t.text;
-  }
-  return out;
+  const entry = parseRichString(isNode);
+  return typeof entry === 'string' ? entry : { kind: 'rich-text', runs: entry.runs };
 };
 
 const decodeCachedValue = (raw: string | undefined, t: string): number | string | boolean | undefined => {

--- a/src/worksheet/writer.ts
+++ b/src/worksheet/writer.ts
@@ -15,7 +15,7 @@ import { dateToExcel, durationToExcel } from '../utils/datetime';
 import { escapeCellString, escapeXmlAttr as escapeXmlAttrShared, escapeXmlText as escapeXmlTextShared } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import type { SharedStringsTable } from '../workbook/shared-strings';
-import { addSharedString, serializeRichTextRuns } from '../workbook/shared-strings';
+import { addSharedRichText, addSharedString } from '../workbook/shared-strings';
 import { MARKUP_COMPAT_NS, SHEET_MAIN_NS, X14_NS } from '../xml/namespaces';
 import { serializeXml } from '../xml/serializer';
 import type { XmlNode } from '../xml/tree';
@@ -310,13 +310,13 @@ export const serializeCell = (cell: Cell, ctx: WorksheetWriteContext): string =>
     return `<c r="${ref}"${styleAttr} t="e"><v>${code}</v></c>`;
   }
   if (typeof value === 'object' && value !== null && (value as { kind?: string }).kind === 'rich-text') {
-    // Emit rich text inline (t="inlineStr") rather than via the shared-strings
-    // table. Excel only honours per-run formatting for inline strings;
-    // rich-text entries inside `xl/sharedStrings.xml` get collapsed back to
-    // plain text on render. This mirrors openpyxl's writer (`cell.write` →
-    // `t="inlineStr"` for CellRichText values).
+    // Rich text goes into the shared-strings table as `<si><r>…</r></si>`,
+    // which is where Excel itself stores it — per-run formatting is honoured
+    // from there, and a formatted string repeated across cells costs one slot
+    // instead of one copy per cell.
     const runs = (value as { kind: 'rich-text'; runs: import('../cell/rich-text').RichText }).runs;
-    return `<c r="${ref}"${styleAttr} t="inlineStr"><is>${serializeRichTextRuns(runs)}</is></c>`;
+    const id = addSharedRichText(ctx.sharedStrings, runs);
+    return `<c r="${ref}"${styleAttr} t="s"><v>${id}</v></c>`;
   }
 
   if (typeof value === 'number') {

--- a/tests/e2e/scenarios/04-rich-text.test.ts
+++ b/tests/e2e/scenarios/04-rich-text.test.ts
@@ -2,12 +2,10 @@
 // Output: 04-rich-text.xlsx
 //
 // What to verify in Excel:
-// - A1 currently shows the runs concatenated as a plain string
-//   (current stage-1 behaviour). Real rich-text fidelity would show
-//   the per-run fonts (bold / italic / colored) — that's a known
-//   residual.
-// - A2 shows the same plain-string result via a non-rich `<t>` cell
-//   for comparison.
+// - A1 shows the per-run fonts (plain / bold / italic / red / 14pt),
+//   stored as an `<si><r>…</r></si>` entry in xl/sharedStrings.xml.
+// - A2 shows the same text unformatted via a plain `<t>` entry for
+//   comparison.
 
 import { describe, expect, it } from 'vitest';
 import { makeRichText, makeTextRun } from '../../../src/cell/index';

--- a/tests/workbook/issue-114.test.ts
+++ b/tests/workbook/issue-114.test.ts
@@ -1,0 +1,123 @@
+// Regression for https://github.com/office-kit/xlsx/issues/114 — a shared
+// string built from `<r>` runs was written back as a single plain `<t>`,
+// losing every run and its `<rPr>` formatting. The loader flattened rich-text
+// `<si>` entries into their concatenated text before the worksheet reader ever
+// saw them, so a cell with a bold first half came back uniformly unformatted.
+
+import { zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { loadWorkbook } from '../../src/io/load';
+import { fromBuffer } from '../../src/io/node';
+import { workbookToBytes } from '../../src/io/save';
+import { getCell } from '../../src/worksheet/worksheet';
+import { openZip } from '../../src/zip/reader';
+import { validateXlsx } from '../conformance/validate';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const MAIN_NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+
+// The reporter's fixture: one `<si>` of two runs, the first bold. B1 points at
+// the same entry so the writer's dedup is exercised too.
+const SHARED_STRINGS =
+  `${XML_DECL}<sst xmlns="${MAIN_NS}" count="2" uniqueCount="1"><si>` +
+  '<r><rPr><b/><sz val="11"/><rFont val="Calibri"/></rPr><t>fett</t></r>' +
+  '<r><t xml:space="preserve"> normal</t></r>' +
+  '</si></sst>';
+
+const buildFixture = (): Uint8Array =>
+  zipSync({
+    '[Content_Types].xml': enc.encode(
+      `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="xml" ContentType="application/xml"/>' +
+        '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+        '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+        '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' +
+        '<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>' +
+        '</Types>',
+    ),
+    '_rels/.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/officeDocument" Target="xl/workbook.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/workbook.xml': enc.encode(
+      `${XML_DECL}<workbook xmlns="${MAIN_NS}" xmlns:r="${REL_NS}">` +
+        '<sheets><sheet name="Tabelle1" sheetId="1" r:id="rId1"/></sheets></workbook>',
+    ),
+    'xl/_rels/workbook.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/worksheet" Target="worksheets/sheet1.xml"/>` +
+        `<Relationship Id="rId8" Type="${REL_NS}/sharedStrings" Target="sharedStrings.xml"/>` +
+        `<Relationship Id="rId9" Type="${REL_NS}/styles" Target="styles.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/styles.xml': enc.encode(
+      `${XML_DECL}<styleSheet xmlns="${MAIN_NS}">` +
+        '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+        '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
+        '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+        '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+        '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>' +
+        '</styleSheet>',
+    ),
+    'xl/sharedStrings.xml': enc.encode(SHARED_STRINGS),
+    'xl/worksheets/sheet1.xml': enc.encode(
+      `${XML_DECL}<worksheet xmlns="${MAIN_NS}" xmlns:r="${REL_NS}"><sheetData><row r="1">` +
+        '<c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>0</v></c>' +
+        '</row></sheetData></worksheet>',
+    ),
+  });
+
+const roundTrip = async (bytes: Uint8Array = buildFixture()): Promise<Uint8Array> =>
+  workbookToBytes(await loadWorkbook(fromBuffer(bytes)));
+
+const partOf = async (bytes: Uint8Array, path: string): Promise<string> => {
+  const archive = await openZip(fromBuffer(bytes));
+  try {
+    return dec.decode(archive.read(path));
+  } finally {
+    archive.close();
+  }
+};
+
+describe('issue #114 — rich-text shared strings keep their runs', () => {
+  it('loads a rich <si> as a rich-text cell value', async () => {
+    const wb = await loadWorkbook(fromBuffer(buildFixture()));
+    const sheet = wb.sheets[0]?.sheet;
+    if (sheet === undefined || !('rows' in sheet)) throw new Error('expected a worksheet');
+    expect(getCell(sheet, 1, 1)?.value).toEqual({
+      kind: 'rich-text',
+      runs: [
+        { text: 'fett', font: { b: true, sz: 11, name: 'Calibri' } },
+        { text: ' normal' },
+      ],
+    });
+  });
+
+  it('writes the runs back into sharedStrings.xml instead of flattening them', async () => {
+    const sst = await partOf(await roundTrip(), 'xl/sharedStrings.xml');
+    expect(sst).toContain('<r><rPr><rFont val="Calibri"/><b/><sz val="11"/></rPr><t>fett</t></r>');
+    expect(sst).toContain('<r><t xml:space="preserve"> normal</t></r>');
+    expect(sst).not.toContain('<t>fett normal</t>');
+  });
+
+  it('dedupes a rich string shared by two cells into one <si>', async () => {
+    const out = await roundTrip();
+    expect(await partOf(out, 'xl/sharedStrings.xml')).toContain('uniqueCount="1"');
+    const sheet = await partOf(out, 'xl/worksheets/sheet1.xml');
+    expect(sheet).toContain('<c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>0</v></c>');
+  });
+
+  it('is byte-stable across a second round-trip and validates', async () => {
+    const once = await roundTrip();
+    const twice = await roundTrip(once);
+    expect(await partOf(twice, 'xl/sharedStrings.xml')).toEqual(await partOf(once, 'xl/sharedStrings.xml'));
+    expect((await validateXlsx(twice)).issues).toEqual([]);
+  });
+});

--- a/tests/worksheet/worksheet-reader.test.ts
+++ b/tests/worksheet/worksheet-reader.test.ts
@@ -44,17 +44,20 @@ describe('parseWorksheetXml — value kinds', () => {
     expect(getCell(ws, 1, 1)?.value).toBe('Hello');
   });
 
-  it('reads inline rich strings by concatenating <r>/<t> runs', () => {
+  it('reads inline rich strings as rich text, one value per <r> run', () => {
     const xml = wrap(`<sheetData>
       <row r="1"><c r="A1" t="inlineStr">
         <is>
-          <r><t>foo</t></r>
+          <r><rPr><b/></rPr><t>foo</t></r>
           <r><t>bar</t></r>
         </is>
       </c></row>
     </sheetData>`);
     const ws = parseWorksheetXml(xml, 'S', { sharedStrings: [] });
-    expect(getCell(ws, 1, 1)?.value).toBe('foobar');
+    expect(getCell(ws, 1, 1)?.value).toEqual({
+      kind: 'rich-text',
+      runs: [{ text: 'foo', font: { b: true } }, { text: 'bar' }],
+    });
   });
 
   it('reads shared-string cells (t="s") via the sst lookup', () => {


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

A shared string built from `<r>` runs was written back as a single plain `<t>`,
losing every run and its `<rPr>`. Anything Excel stores as rich text —
partially bold, coloured or differently sized cell text — came back uniformly
unformatted.

## Motivation

`loadWorkbook` mapped every SST entry through
`e.runs.map(r => r.text).join('')` before handing the table to the worksheet
reader, so the runs were gone before a cell value was ever built. The
worksheet reader did the same thing to inline strings (`<c t="inlineStr">`),
concatenating `<is>/<r>/<t>` into one string.

Closes #114

## Changes

- `<si>` (sharedStrings) and `<is>` (inline string) are both `CT_Rst`, so they
  now share one parser (`parseRichString`). A body built from `<r>` runs
  becomes a `{ kind: 'rich-text' }` cell value; a plain `<t>` body still
  becomes a string.
- `loadWorkbook` no longer flattens the SST on the way in.
- Rich-text cells are written into `xl/sharedStrings.xml` as
  `<si><r>…</r></si>` rather than inlined per cell. That is where Excel itself
  stores them, and it means a formatted string used in many cells costs one
  entry instead of one copy per cell. `SharedStringsTable` gains a
  `richIndex` so those entries dedupe on the structure of their runs.
- `<r>` runs carrying no `<rPr>` stay separate runs — that is how Excel writes
  the unformatted half of a rich string, and merging them would lose the
  boundary in mixed content.

### Behaviour change worth calling out

Cells set to `{ kind: 'rich-text' }` through the public API previously
serialised as `t="inlineStr"`; they now serialise as `t="s"` into the shared
strings table. The rendered result in Excel is the same. The stale claim in
the old code comment — that Excel collapses rich text inside
`sharedStrings.xml` — is contradicted by the reporter's own fixture, which is
Excel-authored and renders bold from the SST.

## Testing

- New `tests/workbook/issue-114.test.ts` — the reporter's shape reduced to a
  minimal package (one `<si>` of two runs, first bold, referenced by two
  cells). Asserts the cell value keeps its runs, the runs come back in
  `sharedStrings.xml` rather than flattened, two cells sharing the string still
  produce one `<si>`, and a second round-trip is byte-stable and passes the
  OPC + XSD + semantic validator. Two of the four fail on `main`.
- `tests/worksheet/worksheet-reader.test.ts` — the inline-rich-string case now
  asserts the runs are kept rather than concatenated.
- `tests/e2e/scenarios/04-rich-text.test.ts` — the "what to verify in Excel"
  note said A1 shows the runs concatenated as plain text; corrected.
- `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm test` (2321 tests),
  `pnpm build`, `pnpm size` green locally.

```sh
pnpm vitest run tests/workbook/issue-114.test.ts
```

### Not addressed here

The report's closing note about `_x000A_` inside `<t>`: the reader decodes it
again, so the round-trip is lossless, and `_x000A_` is Excel's own escape form
for that character. Left alone deliberately rather than folded into a
rich-text fix.

## Breaking changes

None to the API surface. See "Behaviour change worth calling out" above for
the storage change, which is flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->
