### PR TITLE
fix: cells without a value were dropped on save, leaving defined names dangling (#111)

### DIFF
--- a/.changeset/fix-empty-cells-dropped.md
+++ b/.changeset/fix-empty-cells-dropped.md
@@ -1,0 +1,16 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: cells without a value were dropped on save, leaving defined names dangling (#111)
+
+`<c r="B1"/>` and `<c r="C1" s="0"/>` disappeared from the saved sheet: the
+writer skipped any cell whose value was `null` unless it also carried a
+non-default style. Dropping a genuinely unreferenced empty cell is harmless,
+but an empty cell can still be the target of a `definedName`, a form control's
+`fmlaLink`, or a drawing or comment anchor — and those were left pointing at
+nothing.
+
+A valueless cell now always emits. `deleteCell` — not `setCell(…, null)` — is
+how a caller says the cell is gone; cells that were never in the model are
+still not written.

--- a/src/worksheet/writer.ts
+++ b/src/worksheet/writer.ts
@@ -295,9 +295,9 @@ export const serializeCell = (cell: Cell, ctx: WorksheetWriteContext): string =>
   const value = cell.value;
 
   if (value === null) {
-    // Empty-but-styled cells still need to emit so styleId survives the
-    // round-trip.
-    if (cell.styleId === 0) return '';
+    // A valueless cell still has to emit. Its presence is what a defined name,
+    // a form control's fmlaLink or a drawing anchor points at, and `deleteCell`
+    // — not `setCell(…, null)` — is how a caller says the cell is gone.
     return `<c r="${ref}"${styleAttr}/>`;
   }
 

--- a/tests/io/empty-styled-cell.test.ts
+++ b/tests/io/empty-styled-cell.test.ts
@@ -1,9 +1,9 @@
-// Phase 3 — empty-but-styled cells must keep their styleId.
+// Phase 3 — empty cells must survive a round-trip.
 // `<c r="A1" s="N"/>` (no `<v>` / `<f>`) is how Excel represents a
 // cell whose value is empty but whose formatting differs from the
 // sheet default. The writer + reader both have to handle this — and
-// crucially the writer must NOT skip the cell just because its
-// value is null.
+// crucially the writer must NOT skip a cell just because its value
+// is null, styled or not (issue #111).
 
 import { describe, expect, it } from 'vitest';
 import { fromBuffer } from '../../src/io/node';
@@ -11,7 +11,7 @@ import { loadWorkbook } from '../../src/io/load';
 import { workbookToBytes } from '../../src/io/save';
 import { addCellXf, defaultCellXf } from '../../src/styles/stylesheet';
 import { addWorksheet, createWorkbook } from '../../src/workbook/workbook';
-import { setCell } from '../../src/worksheet/worksheet';
+import { deleteCell, setCell } from '../../src/worksheet/worksheet';
 
 describe('phase-3 — empty-styled cells round-trip', () => {
   it('keeps `<c r="A1" s="N"/>` cells across save → load', async () => {
@@ -39,22 +39,25 @@ describe('phase-3 — empty-styled cells round-trip', () => {
     expect(valued?.value).toBe('has-value');
   });
 
-  it('does not emit empty cells when both value and styleId are default', async () => {
+  it('keeps an unstyled empty cell — deleteCell is what removes one', async () => {
+    // A valueless, unstyled cell is still a cell: a defined name, a form
+    // control's fmlaLink or a drawing anchor can point at it (issue #111).
     const wb = createWorkbook();
     const ws = addWorksheet(wb, 'Sheet1');
     setCell(ws, 1, 1, null, 0);
     setCell(ws, 1, 2, 42);
+    setCell(ws, 1, 3, null, 0);
+    deleteCell(ws, 1, 3);
 
     const bytes = await workbookToBytes(wb);
     const wb2 = await loadWorkbook(fromBuffer(bytes));
     const ref0 = wb2.sheets[0];
     if (ref0?.kind !== 'worksheet') throw new Error('expected worksheet');
 
-    // Cell A1 had nothing notable — should not be emitted; the
-    // reload sees only B1.
     const colMap = ref0.sheet.rows.get(1);
-    expect(colMap?.has(1)).toBe(false);
+    expect(colMap?.get(1)?.value).toBeNull();
     expect(colMap?.get(2)?.value).toBe(42);
+    expect(colMap?.has(3)).toBe(false);
   });
 
   it('preserves a row of all-empty-but-styled cells', async () => {

--- a/tests/worksheet/issue-111.test.ts
+++ b/tests/worksheet/issue-111.test.ts
@@ -1,0 +1,102 @@
+// Regression for https://github.com/office-kit/xlsx/issues/111 — a cell with
+// no value and the default style was dropped on save. Dropping a genuinely
+// unreferenced empty cell would be harmless, but an empty cell can still be
+// the target of a `definedName`, a form control's `fmlaLink` or a drawing
+// anchor; the reporter's file kept `<c r="B1"/>` as the target of a defined
+// name, which dangled after a round-trip.
+//
+// `deleteCell` — not `setCell(…, null)` — is how a caller says a cell is gone.
+
+import { zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { loadWorkbook } from '../../src/io/load';
+import { fromBuffer } from '../../src/io/node';
+import { workbookToBytes } from '../../src/io/save';
+import { openZip } from '../../src/zip/reader';
+import { validateXlsx } from '../conformance/validate';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const MAIN_NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+
+// The reporter's fixture: A1 carries a value, B1 is bare, C1 is bare with the
+// default style, and a defined name points at B1.
+const buildFixture = (): Uint8Array =>
+  zipSync({
+    '[Content_Types].xml': enc.encode(
+      `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="xml" ContentType="application/xml"/>' +
+        '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+        '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+        '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' +
+        '</Types>',
+    ),
+    '_rels/.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/officeDocument" Target="xl/workbook.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/workbook.xml': enc.encode(
+      `${XML_DECL}<workbook xmlns="${MAIN_NS}" xmlns:r="${REL_NS}">` +
+        '<sheets><sheet name="Tabelle1" sheetId="1" r:id="rId1"/></sheets>' +
+        '<definedNames><definedName name="Kontrollkaestchen2">Tabelle1!$B$1</definedName></definedNames>' +
+        '</workbook>',
+    ),
+    'xl/_rels/workbook.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/worksheet" Target="worksheets/sheet1.xml"/>` +
+        `<Relationship Id="rId9" Type="${REL_NS}/styles" Target="styles.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/styles.xml': enc.encode(
+      `${XML_DECL}<styleSheet xmlns="${MAIN_NS}">` +
+        '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+        '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
+        '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+        '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+        '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>' +
+        '</styleSheet>',
+    ),
+    'xl/worksheets/sheet1.xml': enc.encode(
+      `${XML_DECL}<worksheet xmlns="${MAIN_NS}" xmlns:r="${REL_NS}"><sheetData>` +
+        '<row r="1"><c r="A1"><v>1</v></c><c r="B1"/><c r="C1" s="0"/></row>' +
+        '</sheetData></worksheet>',
+    ),
+  });
+
+const roundTrip = async (bytes: Uint8Array = buildFixture()): Promise<Uint8Array> =>
+  workbookToBytes(await loadWorkbook(fromBuffer(bytes)));
+
+const sheetXml = async (bytes: Uint8Array): Promise<string> => {
+  const archive = await openZip(fromBuffer(bytes));
+  try {
+    return dec.decode(archive.read('xl/worksheets/sheet1.xml'));
+  } finally {
+    archive.close();
+  }
+};
+
+describe('issue #111 — valueless cells survive a round-trip', () => {
+  it('re-emits <c r="B1"/> so the defined name still resolves', async () => {
+    const xml = await sheetXml(await roundTrip());
+    expect(xml).toContain('<c r="A1"><v>1</v></c><c r="B1"/><c r="C1"/>');
+  });
+
+  it('does not invent cells that were never in the source', async () => {
+    const xml = await sheetXml(await roundTrip());
+    expect(xml).not.toContain('r="D1"');
+    expect(xml).not.toContain('r="A2"');
+  });
+
+  it('is stable across a second round-trip and validates', async () => {
+    const once = await roundTrip();
+    const twice = await roundTrip(once);
+    expect(await sheetXml(twice)).toEqual(await sheetXml(once));
+    expect((await validateXlsx(twice)).issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Cells with no value were skipped on save unless they also carried a
non-default style, so `<c r="B1"/>` disappeared from the output — and the
defined name pointing at it was left dangling.

## Motivation

`serializeCell` returned an empty string for `value === null && styleId === 0`.
Dropping a genuinely unreferenced empty cell is harmless, but an empty cell can
still be the target of:

- a `definedName` (`Tabelle1!$B$1` in the reporter's file),
- a form control's `fmlaLink`,
- a drawing or comment anchor.

The reporter hit it on an Excel-authored template whose check-box control
points at an empty `<c r="C22"/>`. Whether it bites depended on the data,
because cells with a non-default style already survived.

Closes #111

## Changes

- A cell with a `null` value is always written as `<c r="…"/>` (plus `s="N"`
  when styled). `deleteCell` — not `setCell(…, null)` — remains the way to say
  a cell is gone, so cells that were never in the model are still not emitted.
- `tests/io/empty-styled-cell.test.ts` asserted the old behaviour ("does not
  emit empty cells when both value and styleId are default"). That premise is
  what this issue disputes, so the case now asserts the new contract and
  covers `deleteCell` alongside it.

## Testing

- New `tests/worksheet/issue-111.test.ts` — the reporter's fixture reduced to a
  minimal package (A1 valued, B1 bare, C1 bare with `s="0"`, plus a defined
  name pointing at B1). Asserts the bare cells come back, that no cells are
  invented, and that a second round-trip is byte-stable and passes the
  OPC + XSD + semantic validator. Two of the three fail on `main`.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (2328 tests) green locally.

```sh
pnpm vitest run tests/worksheet/issue-111.test.ts
```

## Breaking changes

None to the API. Output changes for workbooks that hold explicitly-created
empty unstyled cells: they are now written out instead of silently dropped.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->
