### PR TITLE
fix: setHyperlink wrote an invalid target verbatim into the rels (#117)

### DIFF
--- a/.changeset/fix-hyperlink-target-validation.md
+++ b/.changeset/fix-hyperlink-target-validation.md
@@ -1,0 +1,20 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: an invalid hyperlink target is now rejected instead of producing a file Excel refuses (#117)
+
+`setHyperlink` accepted any string as `target` and the writer emitted it
+verbatim into the worksheet rels, so `{ target: 'https:// www.example.com' }`
+saved without complaint and Excel then reported "We found a problem with some
+content in …" and dropped content on repair. One bad row poisoned an entire
+export.
+
+The rels `Target` attribute is `xsd:anyURI`. Authoring a hyperlink now throws
+an `OpenXmlSchemaError` when the target is empty, contains whitespace or a
+control character, or has a non-ASCII host (percent-encoding does not rescue
+that one — the host has to be punycode). The check runs in `makeHyperlink`, so
+`setHyperlink`, `addUrlHyperlink` and `addMailtoHyperlink` are all covered.
+
+Reading is deliberately unaffected: a workbook whose rels already carry a
+broken target still loads, so it can be inspected and repaired.

--- a/src/worksheet/hyperlinks.ts
+++ b/src/worksheet/hyperlinks.ts
@@ -22,10 +22,57 @@ export interface Hyperlink {
   rId?: string;
 }
 
+/**
+ * Anything the OPC `Target` attribute (`xsd:anyURI`) cannot carry: whitespace,
+ * C0/C1 controls, and DEL. Excel does not ignore the one bad link — it refuses
+ * the whole package and drops content on repair.
+ */
+const ILLEGAL_TARGET_CHAR = /[\u0000-\u0020\u007f-\u009f]/;
+
+/** The authority of a `scheme://authority/…` target, if the target has one. */
+const AUTHORITY = /^[A-Za-z][A-Za-z0-9+.-]*:\/\/([^/?#]*)/;
+
+const describeChar = (ch: string): string =>
+  ch === ' ' ? 'a space' : `U+${ch.codePointAt(0)?.toString(16).toUpperCase().padStart(4, '0')}`;
+
+/**
+ * Reject a target the writer would emit verbatim into the rels and Excel would
+ * then refuse. Applied when the hyperlink is authored, not when one is read
+ * back off disk — a file that already carries a broken target still loads, so
+ * it can be inspected and repaired.
+ */
+function assertValidTarget(target: string): void {
+  if (target.length === 0) {
+    throw new OpenXmlSchemaError(
+      'Hyperlink: target is empty — pass a URI, or use `location` for an in-workbook jump',
+    );
+  }
+  const illegal = ILLEGAL_TARGET_CHAR.exec(target);
+  if (illegal?.[0] !== undefined) {
+    throw new OpenXmlSchemaError(
+      `Hyperlink: target "${target}" contains ${describeChar(illegal[0])} at index ${illegal.index}. ` +
+        'The rels Target attribute is xsd:anyURI and Excel refuses the file; percent-encode it or drop it.',
+    );
+  }
+  const authority = AUTHORITY.exec(target)?.[1];
+  if (authority !== undefined && /[^\u0021-\u007e]/.test(authority)) {
+    throw new OpenXmlSchemaError(
+      `Hyperlink: target "${target}" has a non-ASCII host. Percent-encoding does not rescue it — ` +
+        'convert the host to punycode (xn--…).',
+    );
+  }
+}
+
+/**
+ * Build a validated {@link Hyperlink}. `target` is checked against what the
+ * OPC `Target` attribute accepts, so a bad URL fails here rather than as an
+ * Excel repair prompt on a package that has already been written.
+ */
 export function makeHyperlink(opts: Partial<Hyperlink> & { ref: string }): Hyperlink {
   if (opts.ref === undefined || opts.ref.length === 0) {
     throw new OpenXmlSchemaError('Hyperlink: ref is required');
   }
+  if (opts.target !== undefined) assertValidTarget(opts.target);
   return {
     ref: opts.ref,
     ...(opts.target !== undefined ? { target: opts.target } : {}),

--- a/src/worksheet/reader.ts
+++ b/src/worksheet/reader.ts
@@ -77,7 +77,6 @@ import type { WebPublishItem, WorksheetCustomProperty } from './web-publish';
 import { makeColor } from '../styles/colors';
 import { makeColumnDimension, makeRowDimension } from './dimensions';
 import type { Hyperlink } from './hyperlinks';
-import { makeHyperlink } from './hyperlinks';
 import type { TableDefinition } from './table';
 import type { Pane, PaneState, PaneType, Selection, SheetView, SheetViewMode } from './views';
 import { makeSheetView } from './views';
@@ -1813,7 +1812,10 @@ const parseHyperlink = (node: XmlNode, rels: Relationships | undefined): Hyperli
   if (node.attrs['location']) opts.location = node.attrs['location'];
   if (node.attrs['tooltip']) opts.tooltip = node.attrs['tooltip'];
   if (node.attrs['display']) opts.display = node.attrs['display'];
-  return makeHyperlink(opts as Hyperlink);
+  // Deliberately not `makeHyperlink`: that validates the target, and a file
+  // whose rels already carry a broken one still has to load so it can be
+  // inspected and repaired. The check belongs where the link is authored.
+  return opts as Hyperlink;
 };
 
 const maybeRecordRowDimension = (ws: Worksheet, node: XmlNode, rowIdx: number): void => {

--- a/src/worksheet/worksheet.ts
+++ b/src/worksheet/worksheet.ts
@@ -1919,6 +1919,10 @@ export function unhideRows(ws: Worksheet, fromRow: number, toRow: number): void 
  * Replace any prior hyperlink on the same `ref` with the given options. Pass `{
  * target }` for an external URL, `{ location }` for an internal jump, or both.
  * Returns the resulting Hyperlink record.
+ *
+ * `target` is validated against what the rels `Target` attribute (`xsd:anyURI`)
+ * accepts — whitespace, control characters and a non-ASCII host throw an
+ * {@link OpenXmlSchemaError} here rather than producing a package Excel refuses.
  */
 export function setHyperlink(
   ws: Worksheet,

--- a/tests/worksheet/issue-117.test.ts
+++ b/tests/worksheet/issue-117.test.ts
@@ -1,0 +1,93 @@
+// Regression for https://github.com/office-kit/xlsx/issues/117 — `setHyperlink`
+// accepted any string as `target` and the writer emitted it verbatim into the
+// worksheet rels. A target that is not a legal `xsd:anyURI` produced a package
+// Excel refuses ("We found a problem with some content in …") and drops
+// content on repair, with no error or warning at save time.
+//
+// The reporter hit four variants in one real export — a trailing space, a
+// space after the scheme, and two umlaut hostnames — where one bad row poisons
+// an export of thousands.
+
+import { describe, expect, it } from 'vitest';
+import { OpenXmlSchemaError } from '../../src/utils/exceptions';
+import { addWorksheet, createWorkbook } from '../../src/workbook/workbook';
+import { addUrlHyperlink, makeHyperlink } from '../../src/worksheet/hyperlinks';
+import { parseWorksheetXml } from '../../src/worksheet/reader';
+import { setCellByCoord, setHyperlink } from '../../src/worksheet/index';
+
+const MAIN_NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+const REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+const sheet = () => addWorksheet(createWorkbook(), 'Tabelle1');
+
+describe('issue #117 — an invalid hyperlink target is rejected where it can be fixed', () => {
+  it.each([
+    ['a space after the scheme', 'https:// www.example.com'],
+    ['a trailing space', 'https://www.example.com '],
+    ['a tab', 'https://www.example.com\tx'],
+    ['a newline', 'https://www.example.com\nx'],
+  ])('rejects %s', (_label, target) => {
+    const ws = sheet();
+    setCellByCoord(ws, 'A1', 'Firma');
+    expect(() => setHyperlink(ws, 'A1', { target })).toThrowError(OpenXmlSchemaError);
+    expect(ws.hyperlinks).toEqual([]);
+  });
+
+  it('rejects a non-ASCII host and points at punycode', () => {
+    const ws = sheet();
+    expect(() => setHyperlink(ws, 'A1', { target: 'https://www.übleis.at' })).toThrowError(/punycode/);
+  });
+
+  it('rejects an empty target', () => {
+    const ws = sheet();
+    expect(() => setHyperlink(ws, 'A1', { target: '' })).toThrowError(/target is empty/);
+  });
+
+  it('accepts the punycode form of the same host', () => {
+    const ws = sheet();
+    const hl = setHyperlink(ws, 'A1', { target: 'https://www.xn--bleis-jva.at' });
+    expect(hl.target).toBe('https://www.xn--bleis-jva.at');
+  });
+
+  it('accepts non-ASCII outside the host, and percent-encoded paths', () => {
+    const ws = sheet();
+    expect(() => addUrlHyperlink(ws, 'A1', 'https://example.com/Größe.pdf')).not.toThrow();
+    expect(() => addUrlHyperlink(ws, 'A2', '../docs/report%20v2.pdf')).not.toThrow();
+  });
+
+  it('still accepts an in-workbook jump with no target at all', () => {
+    const ws = sheet();
+    const hl = setHyperlink(ws, 'A1', { location: "'Tabelle 2'!A1" });
+    expect(hl.location).toBe("'Tabelle 2'!A1");
+  });
+
+  it('rejects the same targets through makeHyperlink', () => {
+    expect(() => makeHyperlink({ ref: 'A1', target: 'https://www.example.com ' })).toThrowError(
+      OpenXmlSchemaError,
+    );
+  });
+
+  it('still loads a file whose rels already carry a broken target', async () => {
+    // The check is on authoring, not on reading: a package that already has
+    // the bad link has to open so it can be inspected and repaired.
+    const ws = parseWorksheetXml(
+      `<worksheet xmlns="${MAIN_NS}" xmlns:r="${REL_NS}"><sheetData/>` +
+        '<hyperlinks><hyperlink ref="A1" r:id="rId1"/></hyperlinks></worksheet>',
+      'Tabelle1',
+      {
+        sharedStrings: [],
+        rels: {
+          rels: [
+            {
+              id: 'rId1',
+              type: `${REL_NS}/hyperlink`,
+              target: 'https:// www.example.com',
+              targetMode: 'External',
+            },
+          ],
+        },
+      },
+    );
+    expect(ws.hyperlinks[0]?.target).toBe('https:// www.example.com');
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`setHyperlink` accepted any string as `target` and the writer wrote it verbatim
into the worksheet rels. A target that is not a legal `xsd:anyURI` — a space, a
tab, an umlaut hostname — produced a package Excel refuses, with no error at
save time. One bad row poisons an export of thousands.

## Motivation

The rels `Target` attribute is `xsd:anyURI`; a raw space is not a legal value,
and Excel does not ignore the one bad link — it reports "We found a problem
with some content in …" and drops content on repair. The reporter hit four
variants in a single real export (company master data with a space or an
umlaut in the website field) and verified that percent-encoding does not
rescue the `http(s)` cases: `https://www.example.com%20` and a `%C3%BC` host
are refused just the same, so encoding at save time is not enough — the
hostname needs punycode and a space is unrepresentable.

Closes #117

## Changes

- `makeHyperlink` validates `target` and throws an `OpenXmlSchemaError` when
  it is empty, contains whitespace / a C0 or C1 control character, or has a
  non-ASCII authority. The message names the offending character and its index,
  and points at punycode for the host case.
- Because `setHyperlink`, `addUrlHyperlink` and `addMailtoHyperlink` all funnel
  through `makeHyperlink`, one check covers every authoring path.
- The worksheet reader no longer routes through `makeHyperlink`: a workbook
  whose rels already carry a broken target still loads, so it can be inspected
  and repaired. The asymmetry is deliberate and commented at both ends.
- `setHyperlink`'s JSDoc documents the new failure mode.

Non-ASCII outside the host (`https://example.com/Größe.pdf`) and
percent-encoded relative paths are unaffected.

## Testing

- New `tests/worksheet/issue-117.test.ts` — the four variants from the report
  plus tab / newline, the empty target, the punycode form of the same host as
  the accepted counter-case, non-ASCII outside the host, a `location`-only
  link, and a check that a file whose rels already carry the bad target still
  loads.
- `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm test` (2336 tests) green
  locally.

```sh
pnpm vitest run tests/worksheet/issue-117.test.ts
```

## Breaking changes

None to the API shape, but `makeHyperlink` / `setHyperlink` / `addUrlHyperlink`
/ `addMailtoHyperlink` now throw on a target they previously accepted. That is
the point of the change — the alternative was a workbook Excel refuses — and
it is called out in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->
