### PR TITLE
fix: drawing shapes were rewritten as chart graphicFrames with an empty r:id (#110)

### DIFF
--- a/.changeset/fix-drawing-raw-content.md
+++ b/.changeset/fix-drawing-raw-content.md
@@ -1,0 +1,22 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: drawing shapes were rewritten as chart graphicFrames with an empty r:id (#110)
+
+An anchor holding anything the model doesn't cover — a shape, a group, a
+connector — was written back as a chart `<xdr:graphicFrame>` carrying
+`<c:chart r:id=""/>`, so a rectangle came back as "Chart 1" with a dangling
+reference, its geometry gone and no drawing rels part written at all. Anchors
+sitting inside Excel's `<mc:AlternateContent>` wrapper were dropped outright,
+leaving an empty `<xdr:wsDr/>`. Together those are what still broke worksheets
+carrying form controls after #105: the worksheet side was fixed, but the shapes
+that draw the controls live in `drawing1.xml`.
+
+Unmodeled drawing content is now kept as the verbatim source XML and written
+back untouched — the whole anchor element, so `editAs` and the
+`<xdr:clientData fLocksWithSheet="0">` flags form controls rely on survive too
+— and `<mc:AlternateContent>` wrappers keep their place in document order,
+which is z-order. Relationships those nodes reference keep their original ids
+and their target parts, and the writer allocates ids for modeled charts and
+pictures around them.

--- a/src/drawing/drawing-xml.ts
+++ b/src/drawing/drawing-xml.ts
@@ -1,11 +1,13 @@
-// `xl/drawings/drawingN.xml` reader/writer. Stage-1 supports anchor
-// envelope round-trip for the chart variant; picture / shape / connector /
-// group remain unsupported placeholders for later iterations.
+// `xl/drawings/drawingN.xml` reader/writer. Charts and pictures are modeled;
+// shapes, connectors and groups — and Excel's `<mc:AlternateContent>` wrappers
+// around an anchor — are kept as the verbatim source XML and written back
+// untouched, because the model has no slot for their geometry or text.
 
 import { escapeXmlAttr } from '../utils/escape';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import { DRAWING_NS, REL_NS, SHEET_DRAWING_NS } from '../xml/namespaces';
 import { parseXml } from '../xml/parser';
+import { serializeXml } from '../xml/serializer';
 import { findChild, type XmlNode } from '../xml/tree';
 import type { AnchorMarker, DrawingAnchor, Point2D, PositiveSize2D } from './anchor';
 import { parseShapeProperties, serializeShapeProperties } from './dml/dml-xml';
@@ -167,14 +169,17 @@ const parseAnchor = (node: XmlNode): DrawingItem | undefined => {
   if (picture) {
     return { anchor, content: { kind: 'picture', picture } };
   }
-  // Find the first child that isn't a marker/pos/ext/clientData.
+  // Find the first child that isn't a marker/pos/ext/clientData. Anything we
+  // don't model keeps the whole anchor element verbatim — rebuilding it would
+  // drop the shape body along with the anchor's own `editAs` and the
+  // `<xdr:clientData fLocksWithSheet="0">` flags form controls rely on.
   const skip = new Set([FROM_TAG, TO_TAG, POS_TAG, EXT_TAG, CLIENT_DATA_TAG]);
   for (const child of node.children) {
     if (skip.has(child.name)) continue;
-    return { anchor, content: { kind: 'unsupported', rawTag: child.name } };
+    return { anchor, content: { kind: 'unsupported', rawTag: child.name }, raw: node };
   }
   // Bare anchor with no content — record as unsupported with empty tag.
-  return { anchor, content: { kind: 'unsupported', rawTag: '' } };
+  return { anchor, content: { kind: 'unsupported', rawTag: '' }, raw: node };
 };
 
 /** Parse a `xl/drawings/drawingN.xml` payload into a Drawing object. */
@@ -184,15 +189,55 @@ export function parseDrawingXml(bytes: Uint8Array | string): Drawing {
     throw new OpenXmlSchemaError(`parseDrawingXml: root is "${root.name}", expected wsDr`);
   }
   const items: DrawingItem[] = [];
+  const rawChildren: Array<{ beforeItem: number; node: XmlNode }> = [];
   // Document order matters — anchors must round-trip in their source
-  // sequence regardless of their kind.
+  // sequence regardless of their kind, and that order is the z-order.
   for (const child of root.children) {
-    if (child.name !== ABSOLUTE_ANCHOR_TAG && child.name !== ONE_CELL_ANCHOR_TAG && child.name !== TWO_CELL_ANCHOR_TAG)
+    if (child.name === ABSOLUTE_ANCHOR_TAG || child.name === ONE_CELL_ANCHOR_TAG || child.name === TWO_CELL_ANCHOR_TAG) {
+      const item = parseAnchor(child);
+      if (item) items.push(item);
       continue;
-    const item = parseAnchor(child);
-    if (item) items.push(item);
+    }
+    // Not an anchor: Excel's `<mc:AlternateContent>` wrapper around one, or
+    // anything else a future schema puts here. Keep it verbatim at its place
+    // in the sequence.
+    rawChildren.push({ beforeItem: items.length, node: child });
   }
-  return makeDrawing(items);
+  const drawing = makeDrawing(items);
+  if (rawChildren.length > 0) drawing.rawChildren = rawChildren;
+  return drawing;
+}
+
+// Declared on the `<xdr:wsDr>` root the fragments below are spliced into, so
+// captured nodes reuse these prefixes instead of redeclaring them per anchor.
+const WS_DR_PREFIXES: Readonly<Record<string, string>> = {
+  [SHEET_DRAWING_NS]: 'xdr',
+  [DRAWING_NS]: 'a',
+};
+
+/** Re-emit a captured node inline, verbatim. */
+const serializeRawNode = (node: XmlNode): string =>
+  new TextDecoder().decode(serializeXml(node, { xmlDeclaration: false, inScopePrefixes: WS_DR_PREFIXES }));
+
+/**
+ * Every relationship id referenced inside the drawing's verbatim nodes —
+ * `r:embed` on a picture nested in a group, `r:id` on a shape's hyperlink, and
+ * whatever else sits under an `<mc:AlternateContent>` wrapper. The loader uses
+ * this to carry the matching rels (and their target parts) across a re-save.
+ */
+export function collectRawRelIds(drawing: Drawing): Set<string> {
+  const ids = new Set<string>();
+  const walk = (node: XmlNode): void => {
+    for (const [name, value] of Object.entries(node.attrs)) {
+      if (name.startsWith(`{${REL_NS}}`) && value.length > 0) ids.add(value);
+    }
+    for (const child of node.children) walk(child);
+  };
+  for (const item of drawing.items) {
+    if (item.raw) walk(item.raw);
+  }
+  for (const rc of drawing.rawChildren ?? []) walk(rc.node);
+  return ids;
 }
 
 const serializeMarker = (tag: string, m: AnchorMarker): string =>
@@ -254,6 +299,7 @@ const serializeChartGraphicFrame = (
 };
 
 const serializeAnchor = (item: DrawingItem, idx: number): string => {
+  if (item.raw) return serializeRawNode(item.raw);
   const a = item.anchor;
   let body = '';
   // Default size for twoCellAnchor where the from→to delta is unknown at this
@@ -275,10 +321,9 @@ const serializeAnchor = (item: DrawingItem, idx: number): string => {
   } else if (item.content.kind === 'picture') {
     content = serializePictureFrame(item.content.picture, idx);
   } else {
-    // Unsupported content: emit a graphicFrame with an empty chart ref so
-    // Excel doesn't choke. Re-emitting unknown content verbatim is the
-    // job of a later iteration (we don't carry the original XmlNode tree
-    // through the data model in stage-1).
+    // Unsupported content with no captured source — only reachable for an item
+    // built in code, since the reader always records `raw`. An empty chart
+    // frame keeps the anchor well-formed.
     content = serializeChartGraphicFrame({}, idx, chartExt);
   }
   const editAs = a.kind === 'twoCell' && a.editAs ? ` editAs="${a.editAs}"` : '';
@@ -296,10 +341,18 @@ function serializeDrawing(drawing: Drawing): string {
     XML_HEADER,
     `<xdr:wsDr xmlns:xdr="${SHEET_DRAWING_NS}" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">`,
   ];
+  const rawChildren = drawing.rawChildren ?? [];
+  const emitRawBefore = (index: number): void => {
+    for (const rc of rawChildren) {
+      if (rc.beforeItem === index) parts.push(serializeRawNode(rc.node));
+    }
+  };
   for (let i = 0; i < drawing.items.length; i++) {
+    emitRawBefore(i);
     const item = drawing.items[i];
     if (item) parts.push(serializeAnchor(item, i));
   }
+  emitRawBefore(drawing.items.length);
   parts.push('</xdr:wsDr>');
   return parts.join('');
 }

--- a/src/drawing/drawing.ts
+++ b/src/drawing/drawing.ts
@@ -2,9 +2,8 @@
 //
 // A `Drawing` is the per-worksheet `xl/drawings/drawingN.xml` part — a list of
 // anchor entries, each carrying a content variant (chart, picture, shape,
-// connector, group). Stage-1 implements the chart variant as a "rels-only"
-// reference (the full ChartML model lands in later iterations); picture / shape
-// / connector / group are reserved for later.
+// connector, group). Charts and pictures are modeled; everything else is kept
+// as the verbatim source XML so it survives a round-trip untouched.
 
 import type { ChartSpace } from '../chart/chart';
 import type { CxChartSpace } from '../chart/cx/chartex';
@@ -59,10 +58,32 @@ export interface DrawingItem {
     | { kind: 'chart'; chart: ChartReference }
     | { kind: 'picture'; picture: PictureReference }
     | { kind: 'unsupported'; rawTag: string };
+  /**
+   * The whole source anchor element, captured verbatim. Set by the reader for
+   * `unsupported` content — a plain shape, a group, a connector — because the
+   * model has no slot for its geometry, text or `<xdr:clientData>` attributes.
+   * When present the writer emits it as-is instead of rebuilding the anchor
+   * from {@link anchor} + {@link content}.
+   */
+  raw?: import('../xml/tree').XmlNode;
 }
 
 export interface Drawing {
   items: DrawingItem[];
+  /**
+   * `<xdr:wsDr>` children that aren't anchors — in practice Excel's
+   * `<mc:AlternateContent>` wrapper around an anchor that needs a newer
+   * feature. Kept verbatim together with the `items` index they sat before, so
+   * document order (which is z-order) survives a round-trip.
+   */
+  rawChildren?: Array<{ beforeItem: number; node: import('../xml/tree').XmlNode }>;
+  /**
+   * Drawing-rels entries the verbatim nodes above reference (`r:embed` on a
+   * picture inside a group, `r:id` on a shape's hyperlink, …). Carried over
+   * from the source part under their original ids so those references still
+   * resolve after a re-save; the writer allocates its own ids around them.
+   */
+  rawRels?: import('../packaging/relationships').Relationships;
 }
 
 export function makeDrawing(items: DrawingItem[] = []): Drawing {

--- a/src/io/load.ts
+++ b/src/io/load.ts
@@ -14,14 +14,14 @@ import { findUserShapesRId, parseChartXml } from '../chart/chart-xml';
 import { isChartExBytes, parseChartExXml } from '../chart/cx/chartex-xml';
 import { parseUserShapesXml } from '../chart/user-shapes-xml';
 import { parseChartsheetXml } from '../chartsheet/chartsheet-xml';
-import { parseDrawingXml } from '../drawing/drawing-xml';
+import { collectRawRelIds, parseDrawingXml } from '../drawing/drawing-xml';
 import { loadImage } from '../drawing/image';
 import type { XlsxSource } from '../io/source';
 import { corePropsFromBytes } from '../packaging/core';
 import { customPropsFromBytes } from '../packaging/custom';
 import { extendedPropsFromBytes } from '../packaging/extended';
 import { manifestFromBytes } from '../packaging/manifest';
-import { findById, indexRelsById, type Relationship, relsFromBytes } from '../packaging/relationships';
+import { findById, indexRelsById, makeRelationships, type Relationship, relsFromBytes } from '../packaging/relationships';
 import { parseStylesheetXml } from '../styles/stylesheet-reader';
 import { OpenXmlSchemaError } from '../utils/exceptions';
 import type { DefinedName } from '../workbook/defined-names';
@@ -447,6 +447,23 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
                   }
                 }
               }
+            }
+            // Anything kept verbatim (shapes, groups, mc:AlternateContent
+            // wrappers) may still reference the drawing's rels. Carry those
+            // entries under their original ids and hand their targets to the
+            // passthrough sweep so the references still resolve on re-save.
+            const rawRelIds = collectRawRelIds(drawing);
+            if (rawRelIds.size > 0) {
+              const carried = makeRelationships();
+              for (const id of rawRelIds) {
+                const rawRel = dRelsById.get(id);
+                if (!rawRel) continue;
+                carried.rels.push(rawRel);
+                if (rawRel.targetMode !== 'External') {
+                  passthroughRoots.push(resolveRelTarget(dPath, rawRel.target));
+                }
+              }
+              if (carried.rels.length > 0) drawing.rawRels = carried;
             }
           }
           return drawing;

--- a/src/io/save.ts
+++ b/src/io/save.ts
@@ -364,11 +364,26 @@ async function saveWorkbookImpl(wb: Workbook, writer: ReturnType<typeof createZi
       // workbook-global chartN id and a per-drawing rId. Emit the chart part +
       // collect a drawing-rels entry so drawing.xml's <c:chart r:id> resolves.
       const drawingRels = makeRelationships();
+      // Rels the drawing's verbatim nodes reference keep their original ids —
+      // those ids are baked into XML we re-emit untouched — so the allocator
+      // below has to step over them.
+      const usedDrawingRIds = new Set<string>();
+      for (const rel of drawing.rawRels?.rels ?? []) {
+        drawingRels.rels.push(rel);
+        usedDrawingRIds.add(rel.id);
+      }
+      let nextDrawingRId = 1;
+      const allocateDrawingRId = (): string => {
+        let candidate = `rId${nextDrawingRId++}`;
+        while (usedDrawingRIds.has(candidate)) candidate = `rId${nextDrawingRId++}`;
+        usedDrawingRIds.add(candidate);
+        return candidate;
+      };
       const itemsForXml: DrawingItem[] = [];
       for (const item of drawing.items) {
         if (item.content.kind === 'chart' && (item.content.chart.space || item.content.chart.cxSpace)) {
           const chartId = nextChartId++;
-          const chartRId = `rId${drawingRels.rels.length + 1}`;
+          const chartRId = allocateDrawingRId();
           // chartex parts use a different relationship Type than the legacy
           // ECMA-376 charts. Excel rejects the workbook when the drawing rels
           // claim a `relationships/chart` target that actually contains a
@@ -428,7 +443,7 @@ async function saveWorkbookImpl(wb: Workbook, writer: ReturnType<typeof createZi
           const img = item.content.picture.image;
           const ext = IMAGE_FORMAT_EXTENSION[img.format];
           const imageId = nextImageId++;
-          const picRId = `rId${drawingRels.rels.length + 1}`;
+          const picRId = allocateDrawingRId();
           drawingRels.rels.push({
             id: picRId,
             type: IMAGE_REL,
@@ -453,7 +468,13 @@ async function saveWorkbookImpl(wb: Workbook, writer: ReturnType<typeof createZi
           itemsForXml.push(item);
         }
       }
-      const emit: DrawingEmit = { id, bytes: drawingToBytes({ items: itemsForXml }) };
+      const emit: DrawingEmit = {
+        id,
+        bytes: drawingToBytes({
+          items: itemsForXml,
+          ...(drawing.rawChildren ? { rawChildren: drawing.rawChildren } : {}),
+        }),
+      };
       if (drawingRels.rels.length > 0) emit.rels = drawingRels;
       drawingEmits.push(emit);
       return { rId };

--- a/src/xml/serializer.ts
+++ b/src/xml/serializer.ts
@@ -26,6 +26,13 @@ export interface SerializeOptions {
   xmlDeclaration?: boolean;
   /** `standalone` attribute on the declaration. Defaults to 'yes'. */
   standalone?: 'yes' | 'no' | 'omit';
+  /**
+   * Namespace URI → prefix already declared by an ancestor, for a fragment
+   * being spliced into a larger document. Those prefixes are reused and not
+   * redeclared on the fragment's own root. Prefixes must be non-empty; the
+   * default namespace is not inheritable this way.
+   */
+  inScopePrefixes?: Readonly<Record<string, string>>;
 }
 
 /**
@@ -35,9 +42,9 @@ export interface SerializeOptions {
  * (which both directions preserve on Node 18+ / V8).
  */
 export function serializeXml(root: XmlNode, opts: SerializeOptions = {}): Uint8Array {
-  const { xmlDeclaration = true, standalone = 'yes' } = opts;
+  const { xmlDeclaration = true, standalone = 'yes', inScopePrefixes } = opts;
 
-  const allocation = allocatePrefixes(root);
+  const allocation = allocatePrefixes(root, inScopePrefixes);
   const out: string[] = [];
 
   if (xmlDeclaration) {
@@ -60,7 +67,7 @@ interface Allocation {
   declarations: Array<{ prefix: string; ns: string }>;
 }
 
-const allocatePrefixes = (root: XmlNode): Allocation => {
+const allocatePrefixes = (root: XmlNode, inScope?: Readonly<Record<string, string>>): Allocation => {
   const used = new Set<string>();
   collectNamespaces(root, used, /* attrsToo */ true);
   used.delete(''); // empty NS = unprefixed names; not emitted as xmlns
@@ -76,6 +83,14 @@ const allocatePrefixes = (root: XmlNode): Allocation => {
 
   const prefixOf = new Map<string, string>();
   if (defaultNs !== '') prefixOf.set(defaultNs, '');
+  // Prefixes an ancestor already declared: reuse them, and leave them out of
+  // this fragment's own declarations.
+  const inherited = new Set<string>();
+  for (const [ns, prefix] of Object.entries(inScope ?? {})) {
+    if (prefix === '' || prefixOf.has(ns)) continue;
+    prefixOf.set(ns, prefix);
+    inherited.add(ns);
+  }
   // `xml` and `xmlns` are reserved by the XMLNS spec; xml ↔ XML_NS is
   // predefined and must NOT be redeclared via xmlns:xml="…".
   prefixOf.set(XML_NS, 'xml');
@@ -83,7 +98,7 @@ const allocatePrefixes = (root: XmlNode): Allocation => {
   // Pass 1: respect DEFAULT_PREFIXES for namespaces that have a
   // canonical short prefix.
   let auto = 0;
-  const usedPrefixes = new Set<string>(['', 'xml', 'xmlns']);
+  const usedPrefixes = new Set<string>(['', 'xml', 'xmlns', ...prefixOf.values()]);
   const ordered = Array.from(used).sort();
   for (const ns of ordered) {
     if (prefixOf.has(ns)) continue;
@@ -109,6 +124,7 @@ const allocatePrefixes = (root: XmlNode): Allocation => {
   for (const ns of ordered) {
     if (ns === defaultNs) continue;
     if (ns === XML_NS) continue;
+    if (inherited.has(ns)) continue;
     const prefix = prefixOf.get(ns);
     if (prefix === undefined) continue;
     declarations.push({ prefix, ns });

--- a/tests/drawing/issue-110.test.ts
+++ b/tests/drawing/issue-110.test.ts
@@ -1,0 +1,216 @@
+// Regression for https://github.com/office-kit/xlsx/issues/110 — an anchor
+// holding anything the model doesn't cover was rewritten as a chart
+// `graphicFrame` with an empty `r:id`, so a rectangle came back as "Chart 1"
+// with a dangling chart reference and no drawing rels part. Anchors sitting
+// inside an `<mc:AlternateContent>` wrapper were dropped outright, leaving an
+// empty `<xdr:wsDr/>` — which is what still broke worksheets carrying form
+// controls after #105: the worksheet side was fixed, but the shapes that draw
+// the controls live in drawing1.xml.
+
+import { zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { loadWorkbook } from '../../src/io/load';
+import { fromBuffer } from '../../src/io/node';
+import { workbookToBytes } from '../../src/io/save';
+import { openZip } from '../../src/zip/reader';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const MAIN_NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+const XDR_NS = 'http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing';
+const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+const A14_NS = 'http://schemas.microsoft.com/office/drawing/2010/main';
+
+// 1×1 PNG-shaped bytes: signature + an IHDR big enough for the dimension read.
+const png = (w: number): Uint8Array =>
+  new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52,
+    0, 0, 0, w, 0, 0, 0, 1, 8, 6, 0, 0, 0,
+  ]);
+
+const MARKER = (tag: string, col: number, row: number): string =>
+  `<xdr:${tag}><xdr:col>${col}</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>${row}</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:${tag}>`;
+
+// The reporter's shape, verbatim.
+const SHAPE_ANCHOR =
+  `<xdr:twoCellAnchor>${MARKER('from', 1, 1)}${MARKER('to', 3, 3)}` +
+  '<xdr:sp macro="" textlink=""><xdr:nvSpPr><xdr:cNvPr id="2" name="Rechteck 1"/><xdr:cNvSpPr/></xdr:nvSpPr>' +
+  '<xdr:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000000" cy="500000"/></a:xfrm>' +
+  '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr></xdr:sp>' +
+  '<xdr:clientData fLocksWithSheet="0"/></xdr:twoCellAnchor>';
+
+// What Excel writes when a shape needs a feature older readers can't render:
+// the anchor itself sits inside the wrapper.
+const ALTERNATE_CONTENT =
+  `<mc:AlternateContent xmlns:mc="${MC_NS}"><mc:Choice xmlns:a14="${A14_NS}" Requires="a14">` +
+  `<xdr:twoCellAnchor>${MARKER('from', 5, 5)}${MARKER('to', 7, 7)}` +
+  '<xdr:sp macro="" textlink=""><xdr:nvSpPr><xdr:cNvPr id="3" name="Ellipse 2"/><xdr:cNvSpPr/></xdr:nvSpPr>' +
+  '<xdr:spPr><a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom></xdr:spPr></xdr:sp>' +
+  '<xdr:clientData/></xdr:twoCellAnchor></mc:Choice></mc:AlternateContent>';
+
+// A group the model doesn't cover, holding a picture — so the raw node carries
+// an r:embed that has to keep resolving.
+const GROUP_ANCHOR =
+  `<xdr:twoCellAnchor>${MARKER('from', 9, 9)}${MARKER('to', 11, 11)}` +
+  '<xdr:grpSp><xdr:nvGrpSpPr><xdr:cNvPr id="4" name="Gruppe 3"/><xdr:cNvGrpSpPr/></xdr:nvGrpSpPr>' +
+  '<xdr:grpSpPr/>' +
+  '<xdr:pic><xdr:nvPicPr><xdr:cNvPr id="5" name="Bild im Verband"/><xdr:cNvPicPr/></xdr:nvPicPr>' +
+  `<xdr:blipFill><a:blip xmlns:r="${REL_NS}" r:embed="rId2"/><a:stretch><a:fillRect/></a:stretch></xdr:blipFill>` +
+  '<xdr:spPr/></xdr:pic></xdr:grpSp><xdr:clientData/></xdr:twoCellAnchor>';
+
+// A picture the model does cover — its rId is reallocated on save, and must
+// not land on the id the raw group still uses.
+const PICTURE_ANCHOR =
+  `<xdr:oneCellAnchor>${MARKER('from', 13, 13)}<xdr:ext cx="500000" cy="500000"/>` +
+  '<xdr:pic><xdr:nvPicPr><xdr:cNvPr id="6" name="Logo"/><xdr:cNvPicPr/></xdr:nvPicPr>' +
+  `<xdr:blipFill><a:blip xmlns:r="${REL_NS}" r:embed="rId1"/><a:stretch><a:fillRect/></a:stretch></xdr:blipFill>` +
+  '<xdr:spPr/></xdr:pic><xdr:clientData/></xdr:oneCellAnchor>';
+
+const DRAWING_XML =
+  `${XML_DECL}<xdr:wsDr xmlns:xdr="${XDR_NS}" xmlns:a="${A_NS}">` +
+  SHAPE_ANCHOR +
+  ALTERNATE_CONTENT +
+  GROUP_ANCHOR +
+  PICTURE_ANCHOR +
+  '</xdr:wsDr>';
+
+const buildFixture = (): Uint8Array =>
+  zipSync({
+    '[Content_Types].xml': enc.encode(
+      `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="xml" ContentType="application/xml"/>' +
+        '<Default Extension="png" ContentType="image/png"/>' +
+        '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+        '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+        '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' +
+        '<Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>' +
+        '</Types>',
+    ),
+    '_rels/.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/officeDocument" Target="xl/workbook.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/workbook.xml': enc.encode(
+      `${XML_DECL}<workbook xmlns="${MAIN_NS}" xmlns:r="${REL_NS}">` +
+        '<sheets><sheet name="Tabelle1" sheetId="1" r:id="rId1"/></sheets></workbook>',
+    ),
+    'xl/_rels/workbook.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/worksheet" Target="worksheets/sheet1.xml"/>` +
+        `<Relationship Id="rId9" Type="${REL_NS}/styles" Target="styles.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/styles.xml': enc.encode(
+      `${XML_DECL}<styleSheet xmlns="${MAIN_NS}">` +
+        '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+        '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
+        '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+        '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+        '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>' +
+        '</styleSheet>',
+    ),
+    'xl/worksheets/sheet1.xml': enc.encode(
+      `${XML_DECL}<worksheet xmlns="${MAIN_NS}" xmlns:r="${REL_NS}"><sheetData/><drawing r:id="rId1"/></worksheet>`,
+    ),
+    'xl/worksheets/_rels/sheet1.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/drawing" Target="../drawings/drawing1.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/drawings/drawing1.xml': enc.encode(DRAWING_XML),
+    'xl/drawings/_rels/drawing1.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/image" Target="../media/image1.png"/>` +
+        `<Relationship Id="rId2" Type="${REL_NS}/image" Target="../media/image2.png"/>` +
+        '</Relationships>',
+    ),
+    'xl/media/image1.png': png(1),
+    'xl/media/image2.png': png(2),
+  });
+
+const roundTrip = async (bytes: Uint8Array = buildFixture()): Promise<Uint8Array> =>
+  workbookToBytes(await loadWorkbook(fromBuffer(bytes)));
+
+interface Package {
+  part(path: string): string;
+  has(path: string): boolean;
+  paths: string[];
+}
+
+const openPackage = async (bytes: Uint8Array): Promise<Package> => {
+  const archive = await openZip(fromBuffer(bytes));
+  try {
+    const paths = archive.list();
+    const parts = new Map<string, string>();
+    for (const p of paths) parts.set(p, dec.decode(archive.read(p)));
+    return {
+      paths,
+      has: (p) => parts.has(p),
+      part: (p) => parts.get(p) ?? '',
+    };
+  } finally {
+    archive.close();
+  }
+};
+
+describe('issue #110 — unmodeled drawing content survives a round-trip', () => {
+  it('keeps the shape instead of rewriting it as an empty chart frame', async () => {
+    const pkg = await openPackage(await roundTrip());
+    const drawing = pkg.part('xl/drawings/drawing1.xml');
+    expect(drawing).toContain('<xdr:cNvPr id="2" name="Rechteck 1"/>');
+    expect(drawing).toContain('<a:prstGeom prst="rect">');
+    expect(drawing).toContain('<a:ext cx="1000000" cy="500000"/>');
+    // The anchor's own clientData flags come back too.
+    expect(drawing).toContain('<xdr:clientData fLocksWithSheet="0"/>');
+    expect(drawing).not.toContain('name="Chart 1"');
+    expect(drawing).not.toContain('r:id=""');
+  });
+
+  it('keeps an mc:AlternateContent-wrapped anchor, in place', async () => {
+    const drawing = (await openPackage(await roundTrip())).part('xl/drawings/drawing1.xml');
+    expect(drawing).toContain('Requires="a14"');
+    expect(drawing).toContain('<xdr:cNvPr id="3" name="Ellipse 2"/>');
+    // Document order is z-order: the wrapper sat between the rectangle and the
+    // group, and has to stay there.
+    expect(drawing.indexOf('Rechteck 1')).toBeLessThan(drawing.indexOf('Ellipse 2'));
+    expect(drawing.indexOf('Ellipse 2')).toBeLessThan(drawing.indexOf('Gruppe 3'));
+  });
+
+  it('keeps the rel a verbatim node references, and its image part', async () => {
+    const pkg = await openPackage(await roundTrip());
+    const drawing = pkg.part('xl/drawings/drawing1.xml');
+    const rels = pkg.part('xl/drawings/_rels/drawing1.xml.rels');
+    // The group still points at rId2, so rId2 has to still be an image rel...
+    expect(drawing).toContain('r:embed="rId2"');
+    const target = /<Relationship Id="rId2"[^>]*Target="([^"]+)"/.exec(rels)?.[1];
+    expect(target).toBeDefined();
+    // ...pointing at a part that exists.
+    const resolved = `xl/${(target as string).replace('../', '')}`;
+    expect(pkg.has(resolved)).toBe(true);
+  });
+
+  it('does not reuse a carried rId for the modeled picture', async () => {
+    const pkg = await openPackage(await roundTrip());
+    const drawing = pkg.part('xl/drawings/drawing1.xml');
+    // The modeled picture is the last anchor; read the r:embed that follows
+    // its cNvPr name.
+    const picRId = /r:embed="(rId\d+)"/.exec(drawing.slice(drawing.indexOf('name="Logo"')))?.[1];
+    expect(picRId).toBeDefined();
+    expect(picRId).not.toBe('rId2');
+  });
+
+  it('is byte-stable across a second round-trip', async () => {
+    const once = await roundTrip();
+    const twice = await roundTrip(once);
+    expect((await openPackage(twice)).part('xl/drawings/drawing1.xml')).toEqual(
+      (await openPackage(once)).part('xl/drawings/drawing1.xml'),
+    );
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

A drawing anchor holding anything the model doesn't cover — a plain shape, a
group, a connector — was written back as a chart `<xdr:graphicFrame>` carrying
`<c:chart r:id=""/>`. A rectangle came back as "Chart 1", its preset geometry
and size replaced by a default chart frame, naming a relationship that does not
exist. Anchors sitting inside Excel's `<mc:AlternateContent>` wrapper were
dropped outright, leaving an empty `<xdr:wsDr/>`.

## Motivation

`parseDrawingXml` recorded unmodeled content as `{ kind: 'unsupported', rawTag }`
— a tag name and nothing else — and the writer's fallback for that was an empty
chart frame, with a comment saying re-emitting the content verbatim was "the
job of a later iteration". Top-level children that weren't anchors were skipped
by the reader entirely.

Together those are what still breaks worksheets carrying form controls after
#105: the worksheet side was fixed there, but the shapes that draw the controls
live in `drawing1.xml`.

Closes #110

## Changes

- `DrawingItem` gains `raw?: XmlNode` — the whole source anchor element,
  captured when the content is unmodeled. The writer emits it as-is instead of
  rebuilding from `anchor` + `content`, so the shape body, `editAs`, and the
  `<xdr:clientData fLocksWithSheet="0">` flags form controls rely on all
  survive.
- `Drawing` gains `rawChildren` — `<xdr:wsDr>` children that aren't anchors
  (Excel's `<mc:AlternateContent>` wrappers), each kept verbatim with the
  `items` index it sat before, so document order — which is z-order — is
  preserved.
- `Drawing` gains `rawRels` — the drawing-rels entries those verbatim nodes
  reference (`r:embed` on a picture nested in a group, `r:id` on a shape's
  hyperlink). They keep their original ids, because the ids are baked into XML
  we re-emit untouched; the loader hands their targets to the passthrough sweep
  so the parts come along, and the writer allocates ids for modeled charts and
  pictures around them instead of colliding.
- `serializeXml` gains `inScopePrefixes`: a fragment spliced into a larger
  document reuses the prefixes its parent already declares rather than
  redeclaring `xmlns:xdr` / `xmlns:a` on every anchor.

With the reporter's fixture, `xl/drawings/drawing1.xml` now comes back
byte-identical.

## Testing

- New `tests/drawing/issue-110.test.ts` — one drawing carrying all four cases:
  the reporter's rectangle, an `mc:AlternateContent`-wrapped anchor between two
  others, a group holding a picture (so the raw node carries an `r:embed`), and
  a modeled picture whose rId is reallocated on save. Asserts the shape and its
  `clientData` flags survive, the wrapper keeps its place in z-order, the
  carried rel still resolves to a part that exists, the modeled picture does not
  land on the carried id, and a second round-trip is byte-stable. Three of the
  five fail on `main`.
- `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm test` (2330 tests),
  `pnpm build`, `pnpm size` green locally.

```sh
pnpm vitest run tests/drawing/issue-110.test.ts
```

## Breaking changes

None. The new fields on `Drawing` / `DrawingItem` are optional; an item built
in code with `kind: 'unsupported'` and no `raw` still gets the old empty-frame
fallback.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->
