### PR TITLE
fix: workbook.xml root lost mc:Ignorable and its namespace declarations on save (#116)

### DIFF
--- a/.changeset/fix-workbook-markup-compat-header.md
+++ b/.changeset/fix-workbook-markup-compat-header.md
@@ -1,0 +1,19 @@
+---
+'@office-kit/xlsx': patch
+---
+
+fix: workbook.xml lost mc:Ignorable and its namespace declarations on save (#116)
+
+Saving a workbook whose `xl/workbook.xml` carries the markup-compatibility
+block Excel writes into essentially every file stripped `mc:Ignorable` and the
+namespace declarations it names off the root, renamed the child prefixes
+(`x15ac:` → a generated `ns0:`, `xr:` → `x16:`), dropped the `xr2:uid` on
+`<workbookView>`, and moved `<workbookPr>` behind the `mc:AlternateContent`
+block. Excel reported the result as corrupt. This is the workbook-level sibling
+of #105, which fixed the same rewrite on the worksheet.
+
+The root's namespace declarations and `mc:Ignorable` are now carried through
+verbatim, and every captured child is written with the prefixes the root
+declares — `mc:Ignorable` names them by prefix, so the two have to agree.
+`<workbookView>` keeps namespaced attributes it doesn't model (`xr2:uid`),
+and the unmodeled head is emitted after `<workbookPr>`, where Excel puts it.

--- a/src/io/load.ts
+++ b/src/io/load.ts
@@ -41,11 +41,12 @@ import {
   ARC_STYLE,
   ARC_THEME,
   ARC_WORKBOOK,
+  MARKUP_COMPAT_NS,
   parseQName,
   REL_NS,
   SHEET_MAIN_NS,
 } from '../xml/namespaces';
-import { parseXml } from '../xml/parser';
+import { type ParsedDocument, parseXmlDocument } from '../xml/parser';
 import { findChild, findChildren, type XmlNode } from '../xml/tree';
 import type { DecompressionLimits } from '../zip/decompression-guard';
 import { openZip, type ZipArchive } from '../zip/reader';
@@ -254,7 +255,8 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
   }
 
   // 3. workbook.xml — parse to extract sheet metadata only.
-  const wbRoot = parseXml(archive.read(workbookPath));
+  const wbDoc = parseXmlDocument(archive.read(workbookPath));
+  const wbRoot = wbDoc.root;
   if (parseQName(wbRoot.name).local !== 'workbook') {
     throw new OpenXmlSchemaError(`loadWorkbook: ${workbookPath} root is "${wbRoot.name}", expected workbook`);
   }
@@ -524,6 +526,7 @@ function loadWorkbookFromArchive(archive: ZipArchive): Workbook {
   }
 
   captureWorkbookXmlExtras(wbRoot, wb);
+  captureWorkbookXmlRoot(wbDoc, wb);
   captureWorkbookRelsExtras(wbRels, wb);
 
   // Pass-through: capture parts we don't model (VBA / pivot / activeX / OLE /
@@ -573,6 +576,23 @@ function captureSheetRelsExtras(
  * things like `<fileVersion>`, `<workbookPr>`, `<bookViews>`, `<calcPr>`,
  * `<pivotCaches>`, `<extLst>` round-trip in document order.
  */
+/**
+ * Keep the `<workbook>` root's namespace declarations and `mc:Ignorable`. Excel
+ * writes `mc:Ignorable="x15 xr xr6 xr10 xr2"` naming prefixes declared only
+ * there; dropping either half — or renaming the prefixes — makes Excel report
+ * the file as corrupt. The default namespace and `r` are re-emitted by the
+ * writer itself, so they are not carried here.
+ */
+function captureWorkbookXmlRoot(doc: ParsedDocument, wb: Workbook): void {
+  const namespaces = doc.rootNamespaces.filter((d) => d.prefix !== '' && d.prefix !== 'r');
+  const ignorable = doc.root.attrs[`{${MARKUP_COMPAT_NS}}Ignorable`];
+  if (namespaces.length === 0 && ignorable === undefined) return;
+  wb.workbookXmlRoot = {
+    namespaces,
+    ...(ignorable !== undefined ? { ignorable } : {}),
+  };
+}
+
 function captureWorkbookXmlExtras(wbRoot: XmlNode, wb: Workbook): void {
   const beforeSheets: XmlNode[] = [];
   const afterSheets: XmlNode[] = [];
@@ -1004,6 +1024,13 @@ const parseWorkbookView = (node: XmlNode): import('../workbook/views').WorkbookV
   if (fs !== undefined) out.firstSheet = fs;
   const at = intAttr('activeTab');
   if (at !== undefined) out.activeTab = at;
+  // `xr2:uid` and friends: anything namespaced is outside CT_BookView, so keep
+  // it verbatim rather than dropping it.
+  const extAttrs: Record<string, string> = {};
+  for (const [k, v] of Object.entries(a)) {
+    if (k.startsWith('{')) extAttrs[k] = v;
+  }
+  if (Object.keys(extAttrs).length > 0) out.extAttrs = extAttrs;
   const adg = flag(a['autoFilterDateGrouping']);
   if (adg !== undefined) out.autoFilterDateGrouping = adg;
   return out;

--- a/src/io/save.ts
+++ b/src/io/save.ts
@@ -51,6 +51,7 @@ import {
   ARC_WORKBOOK_RELS,
   CHARTEX_TYPE,
   CPROPS_TYPE,
+  parseQName,
   PKG_REL_NS,
   REL_NS,
   SHARED_STRINGS_TYPE,
@@ -756,9 +757,22 @@ function nextFreeIndex(wb: Workbook, pattern: RegExp): number {
 
 /** Serialise the minimum `<workbook><sheets/></workbook>` Excel needs to load a sheet list. */
 function serializeWorkbookXml(wb: Workbook, sheetRIds: ReadonlyArray<string>): string {
+  // Excel's markup-compatibility header: the extra prefixes it declares on the
+  // root and the `mc:Ignorable` list naming them. Both are re-emitted exactly
+  // as written, and the same prefix map is handed to every captured child so
+  // `xr:revisionPtr` doesn't come back as `x16:revisionPtr`.
+  const rootNs = wb.workbookXmlRoot?.namespaces ?? [];
+  const nsDecls = rootNs.map((d) => ` xmlns:${d.prefix}="${escapeAttr(d.ns)}"`).join('');
+  const ignorable = wb.workbookXmlRoot?.ignorable;
+  const ignorableAttr = ignorable !== undefined ? ` mc:Ignorable="${escapeAttr(ignorable)}"` : '';
+  const inScopePrefixes: Record<string, string> = { [SHEET_MAIN_NS]: '', [REL_NS]: 'r' };
+  for (const d of rootNs) inScopePrefixes[d.ns] ??= d.prefix;
+  const emitExtra = (node: import('../xml/tree').XmlNode): string =>
+    serializeChildNode(node, inScopePrefixes);
+
   const parts: string[] = [
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
-    `<workbook xmlns="${SHEET_MAIN_NS}" xmlns:r="${REL_NS}">`,
+    `<workbook xmlns="${SHEET_MAIN_NS}" xmlns:r="${REL_NS}"${nsDecls}${ignorableAttr}>`,
   ];
   if (wb.fileVersion) {
     const fv = serializeFileVersion(wb.fileVersion);
@@ -767,9 +781,6 @@ function serializeWorkbookXml(wb: Workbook, sheetRIds: ReadonlyArray<string>): s
   if (wb.fileSharing) {
     const fs = serializeFileSharing(wb.fileSharing);
     if (fs) parts.push(fs);
-  }
-  if (wb.workbookXmlExtras?.beforeSheets) {
-    for (const node of wb.workbookXmlExtras.beforeSheets) parts.push(serializeChildNode(node));
   }
   // Emit <workbookPr> from the typed model; fall back to a minimal {date1904:
   // true} synthesis so a fresh workbook (no load history) still round-trips
@@ -783,7 +794,13 @@ function serializeWorkbookXml(wb: Workbook, sheetRIds: ReadonlyArray<string>): s
     const wp = serializeWorkbookProtection(wb.workbookProtection);
     if (wp) parts.push(wp);
   }
-  if (wb.bookViews && wb.bookViews.length > 0) parts.push(serializeBookViews(wb.bookViews));
+  // The unmodeled head — `mc:AlternateContent`, `xr:revisionPtr` — sits after
+  // `<workbookPr>` in what Excel writes, and CT_Workbook has no slot for it,
+  // so it goes here rather than ahead of the modeled elements.
+  if (wb.workbookXmlExtras?.beforeSheets) {
+    for (const node of wb.workbookXmlExtras.beforeSheets) parts.push(emitExtra(node));
+  }
+  if (wb.bookViews && wb.bookViews.length > 0) parts.push(serializeBookViews(wb.bookViews, inScopePrefixes));
   parts.push('<sheets>');
   wb.sheets.forEach((ref, i) => {
     const stateAttr = ref.state === 'visible' ? '' : ` state="${ref.state}"`;
@@ -855,7 +872,7 @@ function serializeWorkbookXml(wb: Workbook, sheetRIds: ReadonlyArray<string>): s
     if (fp) parts.push(fp);
   }
   if (wb.workbookXmlExtras?.afterSheets) {
-    for (const node of wb.workbookXmlExtras.afterSheets) parts.push(serializeChildNode(node));
+    for (const node of wb.workbookXmlExtras.afterSheets) parts.push(emitExtra(node));
   }
   parts.push('</workbook>');
   return parts.join('');
@@ -1047,7 +1064,10 @@ function serializeCustomWorkbookViews(
   return parts.join('');
 }
 
-function serializeBookViews(views: ReadonlyArray<import('../workbook/views').WorkbookView>): string {
+function serializeBookViews(
+  views: ReadonlyArray<import('../workbook/views').WorkbookView>,
+  prefixOf: Readonly<Record<string, string>>,
+): string {
   const parts: string[] = ['<bookViews>'];
   for (const v of views) {
     let attrs = '';
@@ -1067,6 +1087,14 @@ function serializeBookViews(views: ReadonlyArray<import('../workbook/views').Wor
     if (v.activeTab !== undefined) attrs += ` activeTab="${v.activeTab}"`;
     if (v.autoFilterDateGrouping !== undefined)
       attrs += ` autoFilterDateGrouping="${v.autoFilterDateGrouping ? '1' : '0'}"`;
+    // Namespaced extras (`xr2:uid`) only make sense with a prefix the root
+    // declares; without one the attribute would be unreadable, so skip it.
+    for (const [clark, value] of Object.entries(v.extAttrs ?? {})) {
+      const { ns, local } = parseQName(clark);
+      const prefix = prefixOf[ns];
+      if (prefix === undefined) continue;
+      attrs += ` ${prefix}:${local}="${escapeAttr(value)}"`;
+    }
     parts.push(`<workbookView${attrs}/>`);
   }
   parts.push('</bookViews>');
@@ -1112,11 +1140,17 @@ const escapeAttr = escapeXmlAttr;
 /**
  * Serialise an XmlNode child of `<workbook>` for inline injection back into the
  * workbook XML stream. Reuses serializeXml then strips the declaration.
- * Captured nodes carry Clark-notation names so namespace prefixes get
- * reallocated by serializeXml — Excel tolerates the extra `xmlns="…"`
- * declarations on each captured root.
+ * Captured nodes carry Clark-notation names, so `inScopePrefixes` is what keeps
+ * a child on the prefix the root declared for it instead of a freshly
+ * allocated one — which matters when `mc:Ignorable` names those prefixes.
  */
-function serializeChildNode(node: import('../xml/tree').XmlNode): string {
-  const bytes = serializeXmlNode(node, { xmlDeclaration: false });
+function serializeChildNode(
+  node: import('../xml/tree').XmlNode,
+  inScopePrefixes?: Readonly<Record<string, string>>,
+): string {
+  const bytes = serializeXmlNode(node, {
+    xmlDeclaration: false,
+    ...(inScopePrefixes ? { inScopePrefixes } : {}),
+  });
   return new TextDecoder().decode(bytes);
 }

--- a/src/workbook/views.ts
+++ b/src/workbook/views.ts
@@ -26,6 +26,13 @@ export interface WorkbookView {
   /** Index of the currently active sheet tab (0-based). */
   activeTab?: number;
   autoFilterDateGrouping?: boolean;
+  /**
+   * Namespaced attributes outside SpreadsheetML, keyed in Clark notation
+   * (`{ns}local`). Excel writes `xr2:uid="{…}"` here to tie the view to its
+   * revision-tracking record; kept verbatim because the model has no slot for
+   * it and dropping it changes what Excel reads back.
+   */
+  extAttrs?: Readonly<Record<string, string>>;
 }
 
 export const makeWorkbookView = (opts: WorkbookView = {}): WorkbookView => ({ ...opts });

--- a/src/workbook/workbook.ts
+++ b/src/workbook/workbook.ts
@@ -118,6 +118,18 @@ export interface Workbook {
     afterSheets: import('../xml/tree').XmlNode[];
   };
   /**
+   * The `<workbook>` root's markup-compatibility header, as Excel wrote it:
+   * its namespace declarations and the `mc:Ignorable` list. The two only make
+   * sense together — `mc:Ignorable="x15 xr xr6 …"` names prefixes that are
+   * declared nowhere else — and the captured children have to keep the same
+   * prefixes, so the whole header round-trips verbatim rather than being
+   * rebuilt from the namespaces the serializer happens to walk.
+   */
+  workbookXmlRoot?: {
+    namespaces: ReadonlyArray<{ prefix: string; ns: string }>;
+    ignorable?: string;
+  };
+  /**
    * `<workbookProtection>` — locks structure / window / revision tracking with
    * the modern hash quad or the legacy 16-bit hash. Round-tripped verbatim;
    * password hashing helpers come later.

--- a/src/xml/namespaces.ts
+++ b/src/xml/namespaces.ts
@@ -50,6 +50,10 @@ export const CUSTOMUI_NS = 'http://schemas.microsoft.com/office/2006/relationshi
 export const MARKUP_COMPAT_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
 export const X14_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2009/9/main';
 export const X15_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2010/11/main';
+// "Author capabilities" — the namespace of the `<x15ac:absPath>` Excel writes
+// inside workbook.xml's `mc:Choice Requires="x15"`. Only needed for its
+// canonical prefix, so it isn't exported.
+const X15AC_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2010/11/ac';
 export const X16_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2014/revision';
 export const C14_NS = 'http://schemas.microsoft.com/office/drawing/2010/chart';
 export const C15_NS = 'http://schemas.microsoft.com/office/drawing/2012/chart';
@@ -90,6 +94,7 @@ export const DEFAULT_PREFIXES: Readonly<Record<string, string>> = Object.freeze(
   [MARKUP_COMPAT_NS]: 'mc',
   [X14_NS]: 'x14',
   [X15_NS]: 'x15',
+  [X15AC_NS]: 'x15ac',
   [X16_NS]: 'x16',
   [C14_NS]: 'c14',
   [C15_NS]: 'c15',

--- a/src/xml/parser.ts
+++ b/src/xml/parser.ts
@@ -64,12 +64,33 @@ const TEXT_KEY = '#text';
 
 // ---- public API -------------------------------------------------------------
 
+export interface ParsedDocument {
+  root: XmlNode;
+  /**
+   * The root element's own `xmlns` declarations, in source order (`prefix` is
+   * `''` for the default one). Clark notation carries the namespace but not
+   * the prefix, so these are only needed by parts that must be written back
+   * with the prefixes the producer chose — `xl/workbook.xml`, whose
+   * `mc:Ignorable` names them by prefix.
+   */
+  rootNamespaces: Array<{ prefix: string; ns: string }>;
+}
+
 /**
  * Parse a UTF-8 XML payload into an {@link XmlNode} tree. Element and attribute
  * names are returned in Clark notation. Throws {@link OpenXmlSchemaError} on
  * DTD/entity declarations or on multi-root documents.
+ *
+ * Shorthand for {@link parseXmlDocument} when the root's namespace prefixes
+ * don't matter — which is everywhere except the handful of parts that carry an
+ * `mc:Ignorable`.
  */
 export function parseXml(input: Uint8Array | string): XmlNode {
+  return parseXmlDocument(input).root;
+}
+
+/** {@link parseXml} plus the root element's namespace declarations. */
+export function parseXmlDocument(input: Uint8Array | string): ParsedDocument {
   const text = decodeForPrescan(input);
   checkForDoctype(text);
 
@@ -101,8 +122,17 @@ export function parseXml(input: Uint8Array | string): XmlNode {
   if (root === undefined) {
     throw new OpenXmlSchemaError('parseXml: no root element');
   }
-  return convertElement(root, initial);
+  return { root: convertElement(root, initial), rootNamespaces: declarationsOf(root[ATTR_KEY] as FxpAttrs | undefined) };
 }
+
+const declarationsOf = (attrs: FxpAttrs | undefined): Array<{ prefix: string; ns: string }> => {
+  const out: Array<{ prefix: string; ns: string }> = [];
+  for (const [k, v] of Object.entries(attrs ?? {})) {
+    if (k === 'xmlns') out.push({ prefix: '', ns: v });
+    else if (k.startsWith('xmlns:')) out.push({ prefix: k.slice('xmlns:'.length), ns: v });
+  }
+  return out;
+};
 
 // ---- conversion -------------------------------------------------------------
 

--- a/src/xml/serializer.ts
+++ b/src/xml/serializer.ts
@@ -27,10 +27,11 @@ export interface SerializeOptions {
   /** `standalone` attribute on the declaration. Defaults to 'yes'. */
   standalone?: 'yes' | 'no' | 'omit';
   /**
-   * Namespace URI → prefix already declared by an ancestor, for a fragment
-   * being spliced into a larger document. Those prefixes are reused and not
-   * redeclared on the fragment's own root. Prefixes must be non-empty; the
-   * default namespace is not inheritable this way.
+   * Namespace URI → prefix already bound by an ancestor, for a fragment being
+   * spliced into a larger document. Those bindings are reused and not
+   * redeclared on the fragment's own root. `''` means the ancestor's default
+   * namespace — attributes never inherit a default binding, so only use it for
+   * a namespace whose attributes are unqualified (every SpreadsheetML part).
    */
   inScopePrefixes?: Readonly<Record<string, string>>;
 }
@@ -72,24 +73,25 @@ const allocatePrefixes = (root: XmlNode, inScope?: Readonly<Record<string, strin
   collectNamespaces(root, used, /* attrsToo */ true);
   used.delete(''); // empty NS = unprefixed names; not emitted as xmlns
 
-  // Decide the default namespace. Prefer the root element's NS if its
-  // canonical prefix in DEFAULT_PREFIXES is empty (i.e. designed to live
-  // as a default), so the bulk of the root subtree stays unprefixed.
-  const rootNs = parseQName(root.name).ns;
-  let defaultNs = '';
-  if (rootNs && DEFAULT_PREFIXES[rootNs] === '') {
-    defaultNs = rootNs;
-  }
-
   const prefixOf = new Map<string, string>();
-  if (defaultNs !== '') prefixOf.set(defaultNs, '');
-  // Prefixes an ancestor already declared: reuse them, and leave them out of
+  // Bindings an ancestor already declared: reuse them, and leave them out of
   // this fragment's own declarations.
   const inherited = new Set<string>();
   for (const [ns, prefix] of Object.entries(inScope ?? {})) {
-    if (prefix === '' || prefixOf.has(ns)) continue;
+    if (ns === '' || prefixOf.has(ns)) continue;
     prefixOf.set(ns, prefix);
     inherited.add(ns);
+  }
+
+  // Decide the default namespace. Prefer the root element's NS if its
+  // canonical prefix in DEFAULT_PREFIXES is empty (i.e. designed to live
+  // as a default), so the bulk of the root subtree stays unprefixed — unless
+  // an ancestor already bound that namespace, in which case its binding wins.
+  const rootNs = parseQName(root.name).ns;
+  let defaultNs = '';
+  if (rootNs && DEFAULT_PREFIXES[rootNs] === '' && !prefixOf.has(rootNs)) {
+    defaultNs = rootNs;
+    prefixOf.set(defaultNs, '');
   }
   // `xml` and `xmlns` are reserved by the XMLNS spec; xml ↔ XML_NS is
   // predefined and must NOT be redeclared via xmlns:xml="…".
@@ -121,8 +123,10 @@ const allocatePrefixes = (root: XmlNode, inScope?: Readonly<Record<string, strin
   // URI for determinism. XML_NS is reserved and never declared.
   const declarations: Array<{ prefix: string; ns: string }> = [];
   if (defaultNs !== '') declarations.push({ prefix: '', ns: defaultNs });
+  const inheritedDefault = [...inherited].find((ns) => prefixOf.get(ns) === '');
   for (const ns of ordered) {
     if (ns === defaultNs) continue;
+    if (ns === inheritedDefault) continue;
     if (ns === XML_NS) continue;
     if (inherited.has(ns)) continue;
     const prefix = prefixOf.get(ns);

--- a/tests/io/issue-116.test.ts
+++ b/tests/io/issue-116.test.ts
@@ -1,0 +1,155 @@
+// Regression for https://github.com/office-kit/xlsx/issues/116 — the
+// markup-compatibility header Excel writes on `<workbook>` was destroyed on
+// save: `mc:Ignorable` and the namespace declarations it names disappeared
+// from the root, the captured children came back on generated prefixes
+// (`x15ac:` → `ns0:`, `xr:` → `x16:`), `<workbookPr>` moved behind the
+// `mc:AlternateContent` block and the `xr2:uid` on `<workbookView>` was
+// dropped. Excel then reported the file as corrupt.
+//
+// This is the workbook-level sibling of #105, which fixed the same rewrite on
+// the worksheet.
+
+import { zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { loadWorkbook } from '../../src/io/load';
+import { fromBuffer } from '../../src/io/node';
+import { workbookToBytes } from '../../src/io/save';
+import { openZip } from '../../src/zip/reader';
+import { validateXlsx } from '../conformance/validate';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const MAIN_NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+const X15_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2010/11/main';
+const X15AC_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2010/11/ac';
+const XR_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2014/revision';
+const XR2_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2015/revision2';
+const XR6_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2016/revision6';
+const XR10_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2016/revision10';
+
+// The block Excel writes into essentially every workbook, reduced to one sheet.
+const WORKBOOK_XML =
+  `${XML_DECL}<workbook xmlns="${MAIN_NS}" xmlns:r="${REL_NS}" xmlns:mc="${MC_NS}" ` +
+  `mc:Ignorable="x15 xr xr6 xr10 xr2" xmlns:x15="${X15_NS}" xmlns:xr="${XR_NS}" ` +
+  `xmlns:xr6="${XR6_NS}" xmlns:xr10="${XR10_NS}" xmlns:xr2="${XR2_NS}">` +
+  '<fileVersion appName="xl" lastEdited="7" lowestEdited="7" rupBuild="20415"/>' +
+  '<workbookPr defaultThemeVersion="166925"/>' +
+  `<mc:AlternateContent xmlns:mc="${MC_NS}"><mc:Choice Requires="x15">` +
+  `<x15ac:absPath url="C:\\Vorlagen\\" xmlns:x15ac="${X15AC_NS}"/>` +
+  '</mc:Choice></mc:AlternateContent>' +
+  '<xr:revisionPtr revIDLastSave="0" documentId="13_ncr:1_{00000000-0000-0000-0000-000000000001}" ' +
+  'xr6:coauthVersionLast="36" xr6:coauthVersionMax="36" ' +
+  'xr10:uidLastSave="{00000000-0000-0000-0000-000000000000}"/>' +
+  '<bookViews><workbookView xWindow="0" yWindow="0" windowWidth="20000" windowHeight="12000" ' +
+  'xr2:uid="{00000000-000D-0000-FFFF-FFFF00000000}"/></bookViews>' +
+  '<sheets><sheet name="Tabelle1" sheetId="1" r:id="rId1"/></sheets>' +
+  '<calcPr calcId="191029"/>' +
+  `<extLst><ext uri="{140A7094-0E35-4892-8432-C4D2E57EDEB5}" xmlns:x15="${X15_NS}">` +
+  '<x15:workbookPr chartTrackingRefBase="1"/></ext></extLst>' +
+  '</workbook>';
+
+const buildFixture = (): Uint8Array =>
+  zipSync({
+    '[Content_Types].xml': enc.encode(
+      `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Default Extension="xml" ContentType="application/xml"/>' +
+        '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+        '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+        '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' +
+        '</Types>',
+    ),
+    '_rels/.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/officeDocument" Target="xl/workbook.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/workbook.xml': enc.encode(WORKBOOK_XML),
+    'xl/_rels/workbook.xml.rels': enc.encode(
+      `${XML_DECL}<Relationships xmlns="${PKG_REL_NS}">` +
+        `<Relationship Id="rId1" Type="${REL_NS}/worksheet" Target="worksheets/sheet1.xml"/>` +
+        `<Relationship Id="rId9" Type="${REL_NS}/styles" Target="styles.xml"/>` +
+        '</Relationships>',
+    ),
+    'xl/styles.xml': enc.encode(
+      `${XML_DECL}<styleSheet xmlns="${MAIN_NS}">` +
+        '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>' +
+        '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
+        '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+        '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+        '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>' +
+        '</styleSheet>',
+    ),
+    'xl/worksheets/sheet1.xml': enc.encode(
+      `${XML_DECL}<worksheet xmlns="${MAIN_NS}" xmlns:r="${REL_NS}"><sheetData/></worksheet>`,
+    ),
+  });
+
+const roundTrip = async (bytes: Uint8Array = buildFixture()): Promise<Uint8Array> =>
+  workbookToBytes(await loadWorkbook(fromBuffer(bytes)));
+
+const workbookXml = async (bytes: Uint8Array): Promise<string> => {
+  const archive = await openZip(fromBuffer(bytes));
+  try {
+    return dec.decode(archive.read('xl/workbook.xml'));
+  } finally {
+    archive.close();
+  }
+};
+
+describe("issue #116 — workbook.xml keeps Excel's markup-compatibility header", () => {
+  it('keeps mc:Ignorable and every prefix it names, declared on the root', async () => {
+    const xml = await workbookXml(await roundTrip());
+    const start = xml.indexOf('<workbook ');
+    const root = xml.slice(start, xml.indexOf('>', start) + 1);
+    expect(root).toContain('mc:Ignorable="x15 xr xr6 xr10 xr2"');
+    for (const [prefix, ns] of [
+      ['mc', MC_NS],
+      ['x15', X15_NS],
+      ['xr', XR_NS],
+      ['xr6', XR6_NS],
+      ['xr10', XR10_NS],
+      ['xr2', XR2_NS],
+    ]) {
+      expect(root).toContain(`xmlns:${prefix}="${ns}"`);
+    }
+  });
+
+  it('keeps the child prefixes rather than generating new ones', async () => {
+    const xml = await workbookXml(await roundTrip());
+    expect(xml).toContain('<xr:revisionPtr');
+    expect(xml).toContain('xr6:coauthVersionLast="36"');
+    expect(xml).toContain('xr10:uidLastSave="{00000000-0000-0000-0000-000000000000}"');
+    expect(xml).toContain('<x15ac:absPath url="C:\\Vorlagen\\"/>');
+    expect(xml).not.toContain('ns0:');
+    expect(xml).not.toContain('<x16:revisionPtr');
+  });
+
+  it('keeps <workbookPr> ahead of the mc:AlternateContent block', async () => {
+    const xml = await workbookXml(await roundTrip());
+    expect(xml.indexOf('<workbookPr')).toBeGreaterThan(-1);
+    expect(xml.indexOf('<workbookPr')).toBeLessThan(xml.indexOf('<mc:AlternateContent'));
+    expect(xml.indexOf('<mc:AlternateContent')).toBeLessThan(xml.indexOf('<bookViews>'));
+  });
+
+  it('keeps the xr2:uid on <workbookView>', async () => {
+    const xml = await workbookXml(await roundTrip());
+    expect(xml).toContain('xr2:uid="{00000000-000D-0000-FFFF-FFFF00000000}"');
+  });
+
+  it('is byte-stable across a second round-trip', async () => {
+    const once = await roundTrip();
+    const twice = await roundTrip(once);
+    expect(await workbookXml(twice)).toEqual(await workbookXml(once));
+    // XSD is skipped: the conformance harness strips mc-ignorable content
+    // before validating, which empties this fixture's `<ext>` — the same
+    // complaint it raises about the input file, so it says nothing about the
+    // round-trip. OPC + semantic checks still run.
+    expect((await validateXlsx(twice, { skipXsd: true })).issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Saving a workbook whose `xl/workbook.xml` carries the markup-compatibility
block Excel writes into essentially every file destroyed that block: the
`mc:Ignorable` attribute and the namespace declarations it names vanished from
the root, the children came back on generated prefixes (`x15ac:` → `ns0:`,
`xr:` → `x16:`), `<workbookView>`'s `xr2:uid` was dropped, and `<workbookPr>`
moved behind the `mc:AlternateContent` block. Excel reported the result as
corrupt.

## Motivation

This is the workbook-level sibling of #105, which fixed the same rewrite on the
worksheet. The reporter confirmed on two real Excel-authored templates that
replacing **only** `xl/workbook.xml` in the saved package with the original
made the file open again, and Excel-verified the attached pair: the input
opens, the output triggers the repair prompt.

The cause is that `parseXml` resolves and discards `xmlns:*` declarations —
Clark notation carries the namespace, not the prefix — which is right
everywhere except a part whose `mc:Ignorable` names those prefixes. With the
declarations gone, the serializer allocated its own prefixes on each captured
child and had nothing to write the root header from.

Closes #116

## Changes

- `parseXmlDocument` (new) returns the root's namespace declarations alongside
  the tree; `parseXml` becomes the shorthand for the common case where the
  prefixes don't matter.
- `Workbook.workbookXmlRoot` carries those declarations plus the verbatim
  `mc:Ignorable`. The writer re-emits both on the root and hands the same
  prefix map to every captured child, so `xr:revisionPtr` stays `xr:`.
- `WorkbookView.extAttrs` keeps namespaced attributes the model has no slot
  for — `xr2:uid` ties the view to its revision-tracking record.
- The unmodeled head (`mc:AlternateContent`, `xr:revisionPtr`) is emitted after
  `<workbookPr>` / `<workbookProtection>`, where Excel puts it, instead of
  ahead of them.
- `serializeXml`'s `inScopePrefixes` (added in #110) learns to inherit a
  default-namespace binding, so a captured `<extLst>` no longer redeclares
  `xmlns="…/spreadsheetml/2006/main"`.
- `x15ac` gets its canonical prefix in `DEFAULT_PREFIXES`, so
  `<x15ac:absPath>` — declared inline by Excel rather than on the root — keeps
  its name too.

With the reporter's fixture, `xl/workbook.xml` now round-trips to the input
modulo attribute order on the root element.

## Testing

- New `tests/io/issue-116.test.ts` — the reporter's fixture reduced to one
  sheet. Covers all four losses (root header, child prefixes, `<workbookPr>`
  position, `xr2:uid`) plus byte-stability across a second round-trip. Four of
  the five fail on `main`.
- `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm test` (2353 tests),
  `pnpm build`, `pnpm size` green locally.

```sh
pnpm vitest run tests/io/issue-116.test.ts
```

### One note on the conformance harness

The stability test runs the validator with `skipXsd: true`. The harness strips
mc-ignorable content before validating, which empties this fixture's
`<ext uri="{140A7094-…}">` and makes libxml2 reject it — it raises the same
complaint about the reporter's *input* file, which Excel opens fine, so it says
nothing about the round-trip. OPC and semantic tiers still run. Tightening
mc-strip to drop an `<ext>` left empty is worth a separate look.

## Breaking changes

None. `parseXml` keeps its signature and behaviour; the new fields on
`Workbook` and `WorkbookView` are optional.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->
