### PR TITLE
chore(release): flag the rich-text and hyperlink changes as minor

### DIFF
--- a/.changeset/fix-hyperlink-target-validation.md
+++ b/.changeset/fix-hyperlink-target-validation.md
@@ -1,5 +1,5 @@
 ---
-'@office-kit/xlsx': patch
+'@office-kit/xlsx': minor
 ---
 
 fix: an invalid hyperlink target is now rejected instead of producing a file Excel refuses (#117)
@@ -18,3 +18,8 @@ that one — the host has to be punycode). The check runs in `makeHyperlink`, so
 
 Reading is deliberately unaffected: a workbook whose rels already carry a
 broken target still loads, so it can be inspected and repaired.
+
+**Behaviour change:** `makeHyperlink`, `setHyperlink`, `addUrlHyperlink` and
+`addMailtoHyperlink` now throw on a target they previously accepted. That is
+the point of the change — the alternative was a workbook Excel refuses — but
+it can surface at a call site that used to succeed.

--- a/.changeset/fix-shared-string-rich-text.md
+++ b/.changeset/fix-shared-string-rich-text.md
@@ -1,5 +1,5 @@
 ---
-'@office-kit/xlsx': patch
+'@office-kit/xlsx': minor
 ---
 
 fix: rich text was flattened to plain text on save (#114)
@@ -17,3 +17,9 @@ where Excel itself stores them — instead of being inlined per cell, so a
 formatted string repeated across cells costs one entry rather than one copy
 each. `<r>` runs with no `<rPr>` stay separate runs, since that is how Excel
 writes the unformatted half of a rich string.
+
+**Behaviour change:** a cell whose shared string is rich text now reads back
+as `{ kind: 'rich-text', runs }` where it used to read back as the concatenated
+plain string, and rich-text cells serialise into `xl/sharedStrings.xml` rather
+than as `t="inlineStr"`. Code that assumed `getCell(...).value` was a string
+for those cells needs to handle the union.


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Marks two of the eight round-trip fixes that just landed as `minor` rather than
`patch`, and spells out the behaviour change in each changeset. The release
this produces is `0.10.0`, not `0.9.3`.

## Motivation

CLAUDE.md's OSS discipline section says a change to existing behaviour is a
breaking change — "major bump (post-1.0) or clearly flagged minor (pre-1.0)".
Two of the fixes change behaviour a caller can observe, and I filed both as
`patch`:

- **#114** — a cell whose shared string is rich text now reads back as
  `{ kind: 'rich-text', runs }` where it used to read back as the concatenated
  plain string. Anything doing `getCell(…).value` on such a cell and treating
  it as a string is affected. Rich-text cells also now serialise into
  `xl/sharedStrings.xml` instead of as `t="inlineStr"`.
- **#117** — `makeHyperlink` / `setHyperlink` / `addUrlHyperlink` /
  `addMailtoHyperlink` now throw on a target they previously accepted.

Shipping either as a patch would put a surprise in a version users expect to be
safe.

No issue: this corrects changeset metadata from PRs #122 and #124 before the
"Version Packages" PR is merged.

## Changes

- `.changeset/fix-shared-string-rich-text.md` and
  `.changeset/fix-hyperlink-target-validation.md` bumped from `patch` to
  `minor`, each with a **Behaviour change** paragraph naming what moves and who
  is affected.
- No source changes.

The other six fixes stay `patch` — they change what is written to the package
to match what Excel wrote, without changing an API contract.

## Testing

Metadata only; no source touched. `changesets` recomputes the release PR to
`0.10.0` on merge.

## Breaking changes

None introduced here. This PR is what makes the already-merged behaviour
changes visible in the version number and the changelog.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->
